### PR TITLE
Add control-label class to formgroups to automagically support validatio...

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -84,7 +84,7 @@ class FormHelper extends Helper
             'prepend' => null,
             'append' => null,
             'type' => null,
-            'label' => null,
+            'label' => ['class' => 'control-label'],
             'error' => null,
             'required' => null,
             'options' => null,

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -67,7 +67,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->input('title');
         $expected = [
             'div' => ['class' => 'form-group'],
-            'label' => ['for' => 'title'],
+            'label' => ['for' => 'title', 'class' => 'control-label'],
             'Title',
             '/label',
             'input' => [
@@ -89,7 +89,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->input('password');
         $expected = [
             'div' => ['class' => 'form-group'],
-            'label' => ['for' => 'password'],
+            'label' => ['for' => 'password', 'class' => 'control-label'],
             'Password',
             '/label',
             'input' => [
@@ -110,7 +110,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->input('title');
         $expected = [
             'div' => ['class' => 'form-group'],
-            'label' => ['for' => 'title'],
+            'label' => ['for' => 'title', 'class' => 'control-label'],
             'Title',
             '/label',
             'input' => [
@@ -135,7 +135,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->input('title');
         $expected = [
             'div' => ['class' => 'form-group has-error'],
-            'label' => ['for' => 'title'],
+            'label' => ['for' => 'title', 'class' => 'control-label'],
             'Title',
             '/label',
             'input' => [
@@ -160,7 +160,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->input('title', ['prepend' => '@']);
         $expected = [
             'div' => ['class' => 'form-group'],
-            'label' => ['for' => 'title'],
+            'label' => ['for' => 'title', 'class' => 'control-label'],
             'Title',
             '/label',
             ['div' => ['class' => 'input-group']],
@@ -187,7 +187,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->input('title', ['append' => '@']);
         $expected = [
             'div' => ['class' => 'form-group'],
-            'label' => ['for' => 'title'],
+            'label' => ['for' => 'title', 'class' => 'control-label'],
             'Title',
             '/label',
             ['div' => ['class' => 'input-group']],
@@ -214,7 +214,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->input('title', ['prepend' => $this->Form->button('GO')]);
         $expected = [
             'div' => ['class' => 'form-group'],
-            'label' => ['for' => 'title'],
+            'label' => ['for' => 'title', 'class' => 'control-label'],
             'Title',
             '/label',
             ['div' => ['class' => 'input-group']],
@@ -243,7 +243,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->input('title', ['append' => $this->Form->button('GO')]);
         $expected = [
             'div' => ['class' => 'form-group'],
-            'label' => ['for' => 'title'],
+            'label' => ['for' => 'title', 'class' => 'control-label'],
             'Title',
             '/label',
             ['div' => ['class' => 'input-group']],
@@ -277,7 +277,7 @@ class FormHelperTest extends TestCase
                 'name' => 'published',
                 'value' => 0,
             ],
-            'label' => ['for' => 'published'],
+            'label' => ['for' => 'published', 'class' => 'control-label'],
             ['input' => [
                 'type' => 'checkbox',
                 'name' => 'published',
@@ -303,7 +303,7 @@ class FormHelperTest extends TestCase
                 'name' => 'published',
                 'value' => 0,
             ],
-            'label' => ['class' => 'checkbox-inline', 'for' => 'published'],
+            'label' => ['class' => 'control-label checkbox-inline', 'for' => 'published'],
             ['input' => [
                 'type' => 'checkbox',
                 'name' => 'published',
@@ -385,7 +385,7 @@ class FormHelperTest extends TestCase
         $expected = [
             'div' => ['class' => 'form-group'],
             'label' => [
-                'class' => 'col-md-2',
+                'class' => 'col-md-2 control-label',
                 'for' => 'title'
             ],
             'Title',


### PR DESCRIPTION
Adds the BS3 "control-label" class to all generated formgroup labels which makes the label respect the validation state of the formgroup (http://getbootstrap.com/css/#forms-control-validation). Should be non-obtrusive.

Now needs:

    echo $this->Form->input('url', [
        'label' => ['class' => 'control-label']
    ]); 

After PR:

    echo $this->Form->input('url');