### PR TITLE
Adds has-feedback class to form-groups

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -21,8 +21,8 @@ class FormHelper extends Helper
         $this->_defaultConfig['errorClass'] = null;
         $this->_defaultConfig['templates'] = array_merge($this->_defaultConfig['templates'], [
             'error' => '<div class="text-danger">{{content}}</div>',
-            'inputContainer' => '<div class="form-group">{{content}}</div>',
-            'inputContainerError' => '<div class="form-group has-error">{{content}}{{error}}</div>',
+            'inputContainer' => '<div class="form-group has-feedback">{{content}}</div>',
+            'inputContainerError' => '<div class="form-group has-feedback has-error">{{content}}{{error}}</div>',
             'checkboxWrapper' => '<div class="checkbox"><label>{{input}}{{label}}</label></div>',
             'radioWrapper' => '<div class="radio"><label>{{input}}{{label}}</label></div>',
         ]);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -66,7 +66,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->input('title');
         $expected = [
-            'div' => ['class' => 'form-group'],
+            'div' => ['class' => 'form-group has-feedback'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
             'Title',
             '/label',
@@ -88,7 +88,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->input('password');
         $expected = [
-            'div' => ['class' => 'form-group'],
+            'div' => ['class' => 'form-group has-feedback'],
             'label' => ['class' => 'control-label', 'for' => 'password'],
             'Password',
             '/label',
@@ -109,7 +109,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->input('title');
         $expected = [
-            'div' => ['class' => 'form-group'],
+            'div' => ['class' => 'form-group has-feedback'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
             'Title',
             '/label',
@@ -134,7 +134,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->input('title');
         $expected = [
-            'div' => ['class' => 'form-group has-error'],
+            'div' => ['class' => 'form-group has-feedback has-error'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
             'Title',
             '/label',
@@ -159,7 +159,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->input('title', ['prepend' => '@']);
         $expected = [
-            'div' => ['class' => 'form-group'],
+            'div' => ['class' => 'form-group has-feedback'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
             'Title',
             '/label',
@@ -186,7 +186,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->input('title', ['append' => '@']);
         $expected = [
-            'div' => ['class' => 'form-group'],
+            'div' => ['class' => 'form-group has-feedback'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
             'Title',
             '/label',
@@ -213,7 +213,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->input('title', ['prepend' => $this->Form->button('GO')]);
         $expected = [
-            'div' => ['class' => 'form-group'],
+            'div' => ['class' => 'form-group has-feedback'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
             'Title',
             '/label',
@@ -242,7 +242,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->input('title', ['append' => $this->Form->button('GO')]);
         $expected = [
-            'div' => ['class' => 'form-group'],
+            'div' => ['class' => 'form-group has-feedback'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
             'Title',
             '/label',
@@ -271,7 +271,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->input('published');
         $expected = [
-            'div' => ['class' => 'form-group'],
+            'div' => ['class' => 'form-group has-feedback'],
             'input' => [
                 'type' => 'hidden',
                 'name' => 'published',
@@ -383,7 +383,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->input('title');
         $expected = [
-            'div' => ['class' => 'form-group'],
+            'div' => ['class' => 'form-group has-feedback'],
             'label' => [
                 'class' => 'control-label col-md-2',
                 'for' => 'title'
@@ -405,7 +405,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->input('published');
         $expected = [
-            'div' => ['class' => 'form-group'],
+            'div' => ['class' => 'form-group has-feedback'],
             ['div' => ['class' => 'col-md-offset-2 col-md-10']],
             'input' => [
                 'type' => 'hidden',


### PR DESCRIPTION
Adds the "has-feedback" class to form-group elements to support optional feedback icons out-of-the-box like this example from the [BS3 page on form validation](http://getbootstrap.com/css/#forms-control-validation):

    <div class="form-group has-success has-feedback">
      <label class="control-label" for="inputSuccess2">Input with success</label>
      <input type="text" class="form-control" id="inputSuccess2" aria-describedby="inputSuccess2Status">
      <span class="glyphicon glyphicon-ok form-control-feedback" aria-hidden="true"></span>
      <span id="inputSuccess2Status" class="sr-only">(success)</span>
    </div>
