### PR TITLE
Correct issue with double inputs on multicheckbox

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -119,6 +119,9 @@ class FormHelper extends Helper
             case 'select':
             case 'multiselect':
             case 'textarea':
+                if (isset($options['multiple']) && $options['multiple'] === 'checkbox') {
+                    $this->templates(['checkboxWrapper' => '<div class="checkbox">{{label}}</div>']);
+                }
                 break;
 
             default:

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -121,6 +121,7 @@ class FormHelper extends Helper
             case 'textarea':
                 if (isset($options['multiple']) && $options['multiple'] === 'checkbox') {
                     $this->templates(['checkboxWrapper' => '<div class="checkbox">{{label}}</div>']);
+                    $options['type'] = 'multicheckbox';
                 }
                 break;
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -117,14 +117,14 @@ class FormHelper extends Helper
                 break;
 
             case 'select':
-            case 'multiselect':
-            case 'textarea':
                 if (isset($options['multiple']) && $options['multiple'] === 'checkbox') {
                     $this->templates(['checkboxWrapper' => '<div class="checkbox">{{label}}</div>']);
                     $options['type'] = 'multicheckbox';
                 }
                 break;
-
+            case 'multiselect':
+            case 'textarea':
+                break;
             default:
                 if ($options['label'] !== false && strpos($this->templates('label'), 'class=') === false) {
                     $options['label'] = $this->injectClasses('control-label', (array)$options['label']);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -501,4 +501,56 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
     }
+
+    public function testMultipleCheckboxInput()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->input('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'User 1',
+                2 => 'User 2'
+            ]
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group']],
+            ['label' => []],
+            'Users',
+            '/label',
+            'input' => [
+                'type' => 'hidden',
+                'name' => 'users',
+                'value' => '',
+            ],
+            ['div' => ['class' => 'checkbox']],
+            ['label' => ['for' => 'users-1']],
+            [
+                'input' => [
+                    'type' => 'checkbox',
+                    'name' => 'users[]',
+                    'id' => 'users-1',
+                    'value' => 1,
+                ]
+            ],
+            'User 1',
+            '/label',
+            '/div',
+            ['div' => ['class' => 'checkbox']],
+            ['label' => ['for' => 'users-2']],
+            [
+                'input' => [
+                    'type' => 'checkbox',
+                    'name' => 'users[]',
+                    'id' => 'users-2',
+                    'value' => 2,
+                ]
+            ],
+            'User 2',
+            '/label',
+            '/div',
+            '/div'
+        ];
+        $this->assertHtml($expected, $result);
+    }
 }


### PR DESCRIPTION
Checkboxes are already rendered inside the `{{label}}` element.