### PR TITLE
Add {{required}} placeholder to input containers.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -21,8 +21,8 @@ class FormHelper extends Helper
         $this->_defaultConfig['errorClass'] = null;
         $this->_defaultConfig['templates'] = array_merge($this->_defaultConfig['templates'], [
             'error' => '<div class="text-danger">{{content}}</div>',
-            'inputContainer' => '<div class="form-group">{{content}}</div>',
-            'inputContainerError' => '<div class="form-group has-error">{{content}}{{error}}</div>',
+            'inputContainer' => '<div class="form-group{{required}}">{{content}}</div>',
+            'inputContainerError' => '<div class="form-group{{required}} has-error">{{content}}{{error}}</div>',
             'checkboxWrapper' => '<div class="checkbox"><label>{{input}}{{label}}</label></div>',
             'radioWrapper' => '<div class="radio"><label>{{input}}{{label}}</label></div>',
         ]);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -172,7 +172,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->input('title');
         $expected = [
-            'div' => ['class' => 'form-group'],
+            'div' => ['class' => 'form-group required'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
             'Title',
             '/label',
@@ -197,7 +197,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->input('title');
         $expected = [
-            'div' => ['class' => 'form-group has-error'],
+            'div' => ['class' => 'form-group required has-error'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
             'Title',
             '/label',
@@ -222,7 +222,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->input('title', ['prepend' => '@']);
         $expected = [
-            'div' => ['class' => 'form-group'],
+            'div' => ['class' => 'form-group required'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
             'Title',
             '/label',
@@ -249,7 +249,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->input('title', ['append' => '@']);
         $expected = [
-            'div' => ['class' => 'form-group'],
+            'div' => ['class' => 'form-group required'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
             'Title',
             '/label',
@@ -276,7 +276,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->input('title', ['prepend' => $this->Form->button('GO')]);
         $expected = [
-            'div' => ['class' => 'form-group'],
+            'div' => ['class' => 'form-group required'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
             'Title',
             '/label',
@@ -305,7 +305,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->input('title', ['append' => $this->Form->button('GO')]);
         $expected = [
-            'div' => ['class' => 'form-group'],
+            'div' => ['class' => 'form-group required'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
             'Title',
             '/label',
@@ -444,7 +444,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->input('title');
         $expected = [
-            'div' => ['class' => 'form-group'],
+            'div' => ['class' => 'form-group required'],
             'label' => [
                 'class' => 'control-label col-md-2',
                 'for' => 'title'


### PR DESCRIPTION
While BS does not have a "required" class for form groups, I would like to use it to add extra styling to indicate required fields. This change is unlikely to affect existing users.