### PR TITLE
Fix Error Handling to follow Bootstrap Guidelines

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -100,10 +100,6 @@ class FormHelper extends Helper
 
         switch ($options['type']) {
             case 'checkbox':
-                $this->templates([
-                    'inputContainer' => '<div class="checkbox">{{content}}</div>',
-                    'inputContainerError' => '<div class="has-error"><div class="checkbox">{{content}}{{error}}</div></div>'
-                ]);
             case 'radio':
                 $this->templates(['label' => '{{text}}']);
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -20,7 +20,7 @@ class FormHelper extends Helper
     {
         $this->_defaultConfig['errorClass'] = null;
         $this->_defaultConfig['templates'] = array_merge($this->_defaultConfig['templates'], [
-            'error' => '<div class="text-danger">{{content}}</div>',
+            'error' => '<p class="help-block">{{content}}</p>',
             'inputContainer' => '<div class="form-group">{{content}}</div>',
             'inputContainerError' => '<div class="form-group has-error">{{content}}{{error}}</div>',
             'checkboxWrapper' => '<div class="checkbox"><label>{{input}}{{label}}</label></div>',

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -100,6 +100,10 @@ class FormHelper extends Helper
 
         switch ($options['type']) {
             case 'checkbox':
+                $this->templates([
+                    'inputContainer' => '<div class="checkbox">{{content}}</div>',
+                    'inputContainerError' => '<div class="has-error"><div class="checkbox">{{content}}{{error}}</div></div>'
+                ]);
             case 'radio':
                 $this->templates(['label' => '{{text}}']);
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -334,7 +334,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->input('published');
         $expected = [
-            'div' => ['class' => 'checkbox'],
+            'div' => ['class' => 'form-group'],
             'input' => [
                 'type' => 'hidden',
                 'name' => 'published',
@@ -466,7 +466,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->input('published');
         $expected = [
-            'div' => ['class' => 'checkbox'],
+            'div' => ['class' => 'form-group'],
             ['div' => ['class' => 'col-md-offset-2 col-md-10']],
             ['div' => ['class' => 'checkbox']],
             'input' => [

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -208,9 +208,9 @@ class FormHelperTest extends TestCase
                 'class' => 'form-control ',
                 'required' => 'required'
             ],
-            ['div' => ['class' => 'text-danger']],
+            ['p' => ['class' => 'help-block']],
             'error message',
-            '/div',
+            '/p',
             '/div'
         ];
         $this->assertHtml($expected, $result);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -334,7 +334,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->input('published');
         $expected = [
-            'div' => ['class' => 'form-group'],
+            'div' => ['class' => 'checkbox'],
             'input' => [
                 'type' => 'hidden',
                 'name' => 'published',
@@ -466,7 +466,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->input('published');
         $expected = [
-            'div' => ['class' => 'form-group'],
+            'div' => ['class' => 'checkbox'],
             ['div' => ['class' => 'col-md-offset-2 col-md-10']],
             ['div' => ['class' => 'checkbox']],
             'input' => [


### PR DESCRIPTION
See:
http://getbootstrap.com/css/#forms-example

When the class has-error is set all elements will use anyway red coloring, the current usage of text-danger is wrong.