### PR TITLE
Fixed Error Handling to use intended Bootstrap Elements

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -27,7 +27,7 @@ class FormHelper extends Helper
     {
         $this->_defaultConfig['errorClass'] = null;
         $this->_defaultConfig['templates'] = array_merge($this->_defaultConfig['templates'], [
-            'error' => '<div class="text-danger">{{content}}</div>',
+            'error' => '<p class="help-block">{{content}}</p>',
             'help' => '<p class="help-block">{{content}}</p>',
             'inputContainer' => '<div class="form-group{{required}}">{{content}}{{help}}</div>',
             'inputContainerError' => '<div class="form-group{{required}} has-error">{{content}}{{error}}{{help}}</div>',

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -208,9 +208,9 @@ class FormHelperTest extends TestCase
                 'class' => 'form-control ',
                 'required' => 'required'
             ],
-            ['div' => ['class' => 'text-danger']],
+            ['p' => ['class' => 'help-block']],
             'error message',
-            '/div',
+            '/p',
             '/div'
         ];
         $this->assertHtml($expected, $result);
@@ -619,9 +619,9 @@ class FormHelperTest extends TestCase
                 'class' => 'form-control ',
                 'required' => 'required'
             ],
-            ['div' => ['class' => 'text-danger']],
+            ['p' => ['class' => 'help-block']],
             'error message',
-            '/div',
+            '/p',
             'p' => ['class' => 'help-block'],
             'help text',
             '/p',


### PR DESCRIPTION
The help-block should also be used for error-handling, since all text elements be colored red anyway and the help-block is intended to be placed under a text input unlike text-warning.