### PR TITLE
Better default layout for horizontal.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -64,9 +64,9 @@ class FormHelper extends Helper
             $options = $this->injectClasses('form-horizontal', $options);
             $options['horizontal'] = (array)$options['horizontal'];
             $options['horizontal'] += [
-                'left' => 'col-md-2',
-                'right' => 'col-md-10',
-                'combined' => 'col-md-offset-2 col-md-10'
+                'left' => 'col-md-4 col-sm-2',
+                'right' => 'col-md-8 col-sm-10',
+                'combined' => 'col-md-offset-4 col-md-8 col-sm-offset-2 col-sm-10'
             ];
 
             if (strpos($options['horizontal']['left'], 'control-label') === false) {


### PR DESCRIPTION
For a default cake app there is a lot of space wasted through way too big forms.
And the brake point should be "sm" not "md" IMO.

I also think horizontal should probably be the default.
But with "options" coming to globally activate this, there is probably no reason to change this.