### PR TITLE
Style the default cake dropdowns for date(time) better.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -37,6 +37,7 @@ class FormHelper extends Helper
 
         $this->_defaultWidgets = array_merge($this->_defaultWidgets, [
             'button' => 'BootstrapUI\View\Widget\ButtonWidget',
+			'select' => 'BootstrapUI\View\Widget\SelectBoxWidget'
         ]);
 
         parent::__construct($View, $config);

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -29,8 +29,8 @@ class FormHelper extends Helper
         $this->_defaultConfig['templates'] = array_merge($this->_defaultConfig['templates'], [
             'error' => '<p class="help-block">{{content}}</p>',
             'help' => '<p class="help-block">{{content}}</p>',
-            'inputContainer' => '<div class="form-group{{required}}">{{content}}{{help}}</div>',
-            'inputContainerError' => '<div class="form-group{{required}} has-error">{{content}}{{error}}{{help}}</div>',
+            'inputContainer' => '<div class="form-group {{type}}{{required}}">{{content}}{{help}}</div>',
+            'inputContainerError' => '<div class="form-group {{type}}{{required}} has-error">{{content}}{{error}}{{help}}</div>',
             'checkboxWrapper' => '<div class="checkbox"><label>{{input}}{{label}}</label></div>',
             'radioWrapper' => '<div class="radio"><label>{{input}}{{label}}</label></div>',
         ]);

--- a/src/View/Widget/SelectBoxWidget.php
+++ b/src/View/Widget/SelectBoxWidget.php
@@ -1,0 +1,23 @@
+<?php
+namespace BootstrapUI\View\Widget;
+
+use BootstrapUI\View\Helper\OptionsAwareTrait;
+use Cake\View\Form\ContextInterface;
+
+class SelectBoxWidget extends \Cake\View\Widget\SelectBoxWidget
+{
+
+    use OptionsAwareTrait;
+
+    /**
+     * Renders a select.
+     *
+     * @param array $data The data to build a select with.
+     * @param \Cake\View\Form\ContextInterface $context The current form context.
+     * @return string
+     */
+    public function render(array $data, ContextInterface $context)
+    {
+        return parent::render($this->injectClasses('form-control', $data), $context);
+    }
+}

--- a/webroot/css/bootstrap-u-i.css
+++ b/webroot/css/bootstrap-u-i.css
@@ -4,4 +4,10 @@
     width: auto;
     display: inline-block;
     margin-right: 6px;
+    margin-bottom: 2px;
+}
+
+.form-horizontal .checkbox, .form-horizontal .checkbox-inline, .form-horizontal .radio, .form-horizontal .radio-inline {
+    padding-top: 0px;
+    margin-bottom: 4px;
 }

--- a/webroot/css/bootstrap-u-i.css
+++ b/webroot/css/bootstrap-u-i.css
@@ -1,0 +1,7 @@
+.form-group.date .form-control,
+.form-group.time .form-control,
+.form-group.datetime .form-control {
+    width: auto;
+    display: inline-block;
+    margin-right: 6px;
+}


### PR DESCRIPTION
Before (plain)
![x](https://cloud.githubusercontent.com/assets/39854/6883299/95aa95e4-d5a7-11e4-8e44-e962e70ce8cc.PNG)

After (bootstrap inline form control blocks with auto size)
![y](https://cloud.githubusercontent.com/assets/39854/6883300/9801324e-d5a7-11e4-87c8-f36b05aa348f.PNG)

In general allows more css styling per "type" with the type (re-)added (used to be this way in 2.x) as class name.