### PR TITLE
Fix error when using custom templates file.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2,6 +2,7 @@
 
 namespace BootstrapUI\View\Helper;
 
+use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\View\Helper\FormHelper as Helper;
 use Cake\View\View;
 use InvalidArgumentException;
@@ -362,6 +363,9 @@ class FormHelper extends Helper
         unset($options['align']);
 
         $templates = $this->_config['templateSet'][$this->_align];
+        if (is_string($options['templates'])) {
+            $options['templates'] = (new PhpConfig())->read($options['templates']);
+        }
 
         if ($this->_align === 'default') {
             $options['templates'] += $templates;

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -535,6 +535,28 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
     }
 
+    public function testFormCreateWithTemplatesFile()
+    {
+        unset($this->article['required']['title']);
+        $this->Form->create($this->article, ['templates' => 'custom_templates']);
+
+        $result = $this->Form->input('title');
+        $expected = [
+            'div' => ['class' => 'custom-container form-group'],
+            'label' => ['class' => 'control-label', 'for' => 'title'],
+            'Title',
+            '/label',
+            'input' => [
+                'type' => 'text',
+                'name' => 'title',
+                'id' => 'title',
+                'class' => 'form-control',
+            ],
+            '/div'
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testInlineFormCreate()
     {
         $result = $this->Form->create($this->article, ['class' => 'form-inline']);

--- a/tests/test_files/app/config/custom_templates.php
+++ b/tests/test_files/app/config/custom_templates.php
@@ -1,0 +1,4 @@
+<?php
+return [
+    'inputContainer' => '<div class="custom-container form-group{{required}}">{{content}}{{help}}</div>'
+];


### PR DESCRIPTION
Closes #37 

I chose to directly load the templates file instead of using templater function because that would require backing up / restoring templates, plus StringTemplate::load() also compiles templates which would be unnecessary overhead as the compilation is going to be done later in core's FormHelper::create()  anyway. 