### PR TITLE
radio bugfixes &  improvements

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -30,7 +30,8 @@ class FormHelper extends Helper
         'inputContainer' => '<div class="form-group{{required}}">{{content}}{{help}}</div>',
         'inputContainerError' => '<div class="form-group{{required}} has-error">{{content}}{{error}}{{help}}</div>',
         'checkboxWrapper' => '<div class="checkbox"><label>{{input}}{{label}}</label></div>',
-        'radioFormGroup' => '{{label}}<div class="radio-inline-wrapper">{{input}}</div>',
+        'radioInlineFormGroup' => '{{label}}<div class="radio-inline-wrapper">{{input}}</div>',
+        'radioNestingLabel' => '<div class="radio">{{hidden}}<label{{attrs}}>{{input}}{{text}}</label></div>',
         'staticControl' => '<p class="form-control-static">{{content}}</p>'
     ];
 
@@ -170,14 +171,16 @@ class FormHelper extends Helper
                 break;
             case 'radio':
                 $isInline = (isset($options['inline']) && $options['inline'] === true);
-                if (!$isInline || $this->_align === 'horizontal') {
-                    $this->templater()->remove('radioFormGroup');
+
+                $templates = [];
+                if ($isInline && $this->_align !== 'horizontal') {
+                    $templates['formGroup'] = $this->templater()->get('radioInlineFormGroup');
                 }
                 if (!$isInline) {
-                    $this->templater()->add([
-                        'nestingLabel' => '<div class="radio">' . $this->templater()->get('nestingLabel') . '</div>'
-                    ]);
+                    $templates['nestingLabel'] = $this->templater()->get('radioNestingLabel');
                 }
+
+                $this->templater()->add($templates);
                 break;
             case 'select':
                 if (isset($options['multiple']) && $options['multiple'] === 'checkbox') {

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -30,6 +30,7 @@ class FormHelper extends Helper
         'inputContainer' => '<div class="form-group{{required}}">{{content}}{{help}}</div>',
         'inputContainerError' => '<div class="form-group{{required}} has-error">{{content}}{{error}}{{help}}</div>',
         'checkboxWrapper' => '<div class="checkbox"><label>{{input}}{{label}}</label></div>',
+        'multipleCheckboxWrapper' => '<div class="checkbox">{{label}}</div>',
         'radioInlineFormGroup' => '{{label}}<div class="radio-inline-wrapper">{{input}}</div>',
         'radioNestingLabel' => '<div class="radio">{{hidden}}<label{{attrs}}>{{input}}{{text}}</label></div>',
         'staticControl' => '<p class="form-control-static">{{content}}</p>'
@@ -184,7 +185,9 @@ class FormHelper extends Helper
                 break;
             case 'select':
                 if (isset($options['multiple']) && $options['multiple'] === 'checkbox') {
-                    $this->templates(['checkboxWrapper' => '<div class="checkbox">{{label}}</div>']);
+                    $this->templater()->add([
+                        'checkboxWrapper' => $this->templater()->get('multipleCheckboxWrapper')
+                    ]);
                     $options['type'] = 'multicheckbox';
                 }
                 break;

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -30,6 +30,7 @@ class FormHelper extends Helper
         'inputContainer' => '<div class="form-group{{required}}">{{content}}{{help}}</div>',
         'inputContainerError' => '<div class="form-group{{required}} has-error">{{content}}{{error}}{{help}}</div>',
         'checkboxWrapper' => '<div class="checkbox"><label>{{input}}{{label}}</label></div>',
+        'radioFormGroup' => '{{label}}<div class="radio-inline-wrapper">{{input}}</div>',
         'staticControl' => '<p class="form-control-static">{{content}}</p>'
     ];
 
@@ -166,7 +167,17 @@ class FormHelper extends Helper
                 if ($options['inline']) {
                     $options['label'] = $this->injectClasses($options['type'] . '-inline', (array)$options['label']);
                 }
-
+                break;
+            case 'radio':
+                $isInline = (isset($options['inline']) && $options['inline'] === true);
+                if (!$isInline || $this->_align === 'horizontal') {
+                    $this->templater()->remove('radioFormGroup');
+                }
+                if (!$isInline) {
+                    $this->templater()->add([
+                        'nestingLabel' => '<div class="radio">' . $this->templater()->get('nestingLabel') . '</div>'
+                    ]);
+                }
                 break;
             case 'select':
                 if (isset($options['multiple']) && $options['multiple'] === 'checkbox') {
@@ -174,7 +185,6 @@ class FormHelper extends Helper
                     $options['type'] = 'multicheckbox';
                 }
                 break;
-            case 'radio':
             case 'multiselect':
             case 'textarea':
                 break;

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -30,7 +30,6 @@ class FormHelper extends Helper
         'inputContainer' => '<div class="form-group{{required}}">{{content}}{{help}}</div>',
         'inputContainerError' => '<div class="form-group{{required}} has-error">{{content}}{{error}}{{help}}</div>',
         'checkboxWrapper' => '<div class="checkbox"><label>{{input}}{{label}}</label></div>',
-        'radioFormGroup' => '{{input}}',
         'staticControl' => '<p class="form-control-static">{{content}}</p>'
     ];
 
@@ -52,7 +51,6 @@ class FormHelper extends Helper
             'label' => '<label class="control-label %s"{{attrs}}>{{text}}</label>',
             'formGroup' => '{{label}}<div class="%s">{{input}}{{error}}{{help}}</div>',
             'checkboxFormGroup' => '<div class="%s"><div class="checkbox">{{label}}</div>{{error}}{{help}}</div>',
-            'radioFormGroup' => '<div class="%s"><div class="radio">{{label}}</div>{{error}}{{help}}</div>',
             'submitContainer' => '<div class="%s">{{content}}</div>',
             'inputContainer' => '<div class="form-group{{required}}">{{content}}</div>',
             'inputContainerError' => '<div class="form-group{{required}} has-error">{{content}}</div>',
@@ -161,7 +159,6 @@ class FormHelper extends Helper
 
         switch ($options['type']) {
             case 'checkbox':
-            case 'radio':
                 if (!isset($options['inline'])) {
                     $options['inline'] = $this->checkClasses($options['type'] . '-inline', (array)$options['label']);
                 }
@@ -177,6 +174,7 @@ class FormHelper extends Helper
                     $options['type'] = 'multicheckbox';
                 }
                 break;
+            case 'radio':
             case 'multiselect':
             case 'textarea':
                 break;
@@ -385,7 +383,7 @@ class FormHelper extends Helper
 
         $templates['label'] = sprintf($templates['label'], $this->_gridClass('left'));
         $templates['formGroup'] = sprintf($templates['formGroup'], $this->_gridClass('middle'));
-        foreach (['checkboxFormGroup', 'radioFormGroup', 'submitContainer'] as $value) {
+        foreach (['checkboxFormGroup', 'submitContainer'] as $value) {
             $templates[$value] = sprintf($templates[$value], $offsetedGridClass);
         }
 

--- a/src/View/Widget/RadioWidget.php
+++ b/src/View/Widget/RadioWidget.php
@@ -41,21 +41,7 @@ class RadioWidget extends \Cake\View\Widget\RadioWidget
             'inline' => false,
         ];
 
-        $templates = $this->_templates->get();
-        $customize = [];
-
-        if ($data['inline']) {
-            $this->_inline = $data['inline'];
-            if ($templates['formGroup'] === '{{label}}{{input}}') {
-                $this->_templates->add(['radioFormGroup' => '{{label}}<div class="radio-inline-wrapper">{{input}}</div>']);
-            }
-        }
-
-        if (!$data['inline'] && $templates['nestingLabel'] === '{{hidden}}<label{{attrs}}>{{input}}{{text}}</label>') {
-            $customize['nestingLabel'] = '<div class="radio">' . $templates['nestingLabel'] . '</div>';
-        }
-
-        $this->_templates->add($customize);
+        $this->_inline = $data['inline'];
 
         unset($data['inline']);
 

--- a/src/View/Widget/RadioWidget.php
+++ b/src/View/Widget/RadioWidget.php
@@ -5,6 +5,15 @@ use Cake\View\Form\ContextInterface;
 
 class RadioWidget extends \Cake\View\Widget\RadioWidget
 {
+
+    /**
+     * Set on `RadioWidget::render()` to tell `RadioWidget::_renderLabel()`
+     * that we want to have inline aligned radios.
+     *
+     * @var bool
+     */
+    protected $_inline = false;
+
     /**
      * Render a set of radio buttons.
      *
@@ -32,20 +41,49 @@ class RadioWidget extends \Cake\View\Widget\RadioWidget
             'inline' => false,
         ];
 
-        if ($data['inline']) {
-            $this->_templates->add(['radioContainer' => '{{content}}']);
-        }
-
-
         $templates = $this->_templates->get();
         $customize = [];
-        if ($templates['nestingLabel'] === '{{hidden}}<label{{attrs}}>{{input}}{{text}}</label>') {
+
+        if ($data['inline']) {
+            $this->_inline = $data['inline'];
+            if ($templates['formGroup'] === '{{label}}{{input}}') {
+                $this->_templates->add(['radioFormGroup' => '{{label}}<div class="radio-inline-wrapper">{{input}}</div>']);
+            }
+        }
+
+        if (!$data['inline'] && $templates['nestingLabel'] === '{{hidden}}<label{{attrs}}>{{input}}{{text}}</label>') {
             $customize['nestingLabel'] = '<div class="radio">' . $templates['nestingLabel'] . '</div>';
         }
+
         $this->_templates->add($customize);
 
         unset($data['inline']);
 
         return parent::render($data, $context);
     }
+
+    /**
+     * Renders a label element for a given radio button.
+     *
+     * In the future this might be refactored into a separate widget as other
+     * input types (multi-checkboxes) will also need labels generated.
+     *
+     * @param array $radio The input properties.
+     * @param false|string|array $label The properties for a label.
+     * @param string $input The input widget.
+     * @param \Cake\View\Form\ContextInterface $context The form context.
+     * @param bool $escape Whether or not to HTML escape the label.
+     * @return string Generated label.
+     */
+    protected function _renderLabel($radio, $label, $input, $context, $escape)
+    {
+        if ($this->_inline) {
+            $label = [
+                'text' => $radio['text'],
+                'class' => 'radio-inline'
+            ];
+        }
+        return parent::_renderLabel($radio, $label, $input, $context, $escape);
+    }
+
 }

--- a/src/View/Widget/RadioWidget.php
+++ b/src/View/Widget/RadioWidget.php
@@ -67,5 +67,4 @@ class RadioWidget extends \Cake\View\Widget\RadioWidget
         }
         return parent::_renderLabel($radio, $label, $input, $context, $escape);
     }
-
 }

--- a/src/View/Widget/RadioWidget.php
+++ b/src/View/Widget/RadioWidget.php
@@ -40,11 +40,7 @@ class RadioWidget extends \Cake\View\Widget\RadioWidget
         $data += [
             'inline' => false,
         ];
-
         $this->_inline = $data['inline'];
-
-        unset($data['inline']);
-
         return parent::render($data, $context);
     }
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -430,14 +430,20 @@ class FormHelperTest extends TestCase
     {
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('published', ['type' => 'radio', 'options' => ['Yes', 'No']]);
+        $result = $this->Form->input('published', [
+            'type' => 'radio',
+            'options' => ['Yes', 'No']
+        ]);
         $expected = [
             ['div' => ['class' => 'form-group']],
-            'input' => [
+            ['label' => true],
+            'Published',
+            '/label',
+            ['input' => [
                 'type' => 'hidden',
                 'name' => 'published',
                 'value' => '',
-            ],
+            ]],
             ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'published-0']],
             ['input' => [
@@ -460,6 +466,7 @@ class FormHelperTest extends TestCase
             'No',
             '/label',
             '/div',
+            '/div'
         ];
         $this->assertHtml($expected, $result);
     }
@@ -474,6 +481,67 @@ class FormHelperTest extends TestCase
             'options' => ['Yes', 'No']
         ]);
         $expected = [
+            ['div' => ['class' => 'form-group']],
+            ['label' => true],
+            'Published',
+            '/label',
+            ['div' => ['class' => 'radio-inline-wrapper']],
+            ['input' => [
+                'type' => 'hidden',
+                'name' => 'published',
+                'value' => ''
+            ]],
+            ['label' => [
+                'class' => 'radio-inline',
+                'for' => 'published-0'
+            ]],
+            ['input' => [
+                'type' => 'radio',
+                'name' => 'published',
+                'value' => 0,
+                'id' => 'published-0'
+            ]],
+            'Yes',
+            '/label',
+            ['label' => [
+                'class' => 'radio-inline',
+                'for' => 'published-1'
+            ]],
+            ['input' => [
+                'type' => 'radio',
+                'name' => 'published',
+                'value' => 1,
+                'id' => 'published-1'
+            ]],
+            'No',
+            '/label',
+            '/div',
+            '/div'
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testRadioInputHorizontal()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7
+                ]
+            ]
+        ]);
+
+        $result = $this->Form->input('published', [
+            'type' => 'radio',
+            'options' => ['Yes', 'No']
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group']],
+            ['label' => ['class' => 'control-label col-sm-5']],
+            'Published',
+            '/label',
+            ['div' => ['class' => 'col-sm-7']],
             'input' => [
                 'type' => 'hidden',
                 'name' => 'published',
@@ -500,14 +568,67 @@ class FormHelperTest extends TestCase
             ]],
             'No',
             '/label',
+            '/div',
+            '/div',
+            '/div'
         ];
         $this->assertHtml($expected, $result);
+    }
+
+    public function testInlineRadioInputHorizontal()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7
+                ]
+            ]
+        ]);
 
         $result = $this->Form->input('published', [
-            'label' => ['class' => 'radio-inline'],
+            'inline' => true,
             'type' => 'radio',
             'options' => ['Yes', 'No']
         ]);
+        $expected = [
+            ['div' => ['class' => 'form-group']],
+            ['label' => ['class' => 'control-label col-sm-5']],
+            'Published',
+            '/label',
+            ['div' => ['class' => 'col-sm-7']],
+            'input' => [
+                'type' => 'hidden',
+                'name' => 'published',
+                'value' => '',
+            ],
+            ['label' => [
+                'class' => 'radio-inline',
+                'for' => 'published-0'
+            ]],
+            ['input' => [
+                'type' => 'radio',
+                'name' => 'published',
+                'value' => 0,
+                'id' => 'published-0',
+            ]],
+            'Yes',
+            '/label',
+            ['label' => [
+                'class' => 'radio-inline',
+                'for' => 'published-1'
+            ]],
+            ['input' => [
+                'type' => 'radio',
+                'name' => 'published',
+                'value' => 1,
+                'id' => 'published-1',
+            ]],
+            'No',
+            '/label',
+            '/div',
+            '/div'
+        ];
         $this->assertHtml($expected, $result);
     }
 


### PR DESCRIPTION
Don't care about the test cases yet, I will write them when you're fine with the changes.

### Before the changes

(1)
```
echo $this->Form->input('radio', [
    'type' => 'radio',
    'options' => [
        'First Radio', 'Second Radio', 'Third Radio'
    ]
]);
```
![image](https://cloud.githubusercontent.com/assets/5982785/8150840/0d05aa22-12fa-11e5-88ac-5f38195879bf.png)

- It was not possible to show the label, even with `label => true`

![image](https://cloud.githubusercontent.com/assets/5982785/8150814/57612124-12f9-11e5-85a7-c6dc5ec4d23a.png)


(2)
```
echo $this->Form->input('radio', [
    'type' => 'radio',
    'inline' => true,
    'options' => [
        'First Radio', 'Second Radio', 'Third Radio'
    ]
]);
```
![image](https://cloud.githubusercontent.com/assets/5982785/8150851/97974efc-12fa-11e5-80ab-c7cac690b695.png)

- The radios are not aligned correctly
- No container at all

![image](https://cloud.githubusercontent.com/assets/5982785/8150849/75184ac0-12fa-11e5-9b3e-73e37a0d6dae.png)

(3) With `form-horizontal`
```
echo $this->Form->input('radio', [
    'type' => 'radio',
    'options' => [
        'First Radio', 'Second Radio', 'Third Radio'
    ]
]);
```
![image](https://cloud.githubusercontent.com/assets/5982785/8150861/1a9b9d80-12fb-11e5-816d-6f1b91d4fb1c.png)

- As you can see, completly broken

![image](https://cloud.githubusercontent.com/assets/5982785/8150862/2ba4faea-12fb-11e5-9c15-cba8ffc62054.png)

### After changes

(1)
![image](https://cloud.githubusercontent.com/assets/5982785/8150869/68eba552-12fb-11e5-8490-04e8ad63c4cb.png)

- Label is customizable, you can event switch off with `label => false`

(2)
![image](https://cloud.githubusercontent.com/assets/5982785/8150872/9d67a90c-12fb-11e5-8eec-94e7682a7a68.png)

- Alignment is correct
- Label is customizable, you can even switch off with `label => false`

(3) With `form-horizontal`

(3.1) Default aligment
![image](https://cloud.githubusercontent.com/assets/5982785/8150883/f3ba368a-12fb-11e5-8f58-024e6ce5f326.png)

(3.2) Inline aligment
![image](https://cloud.githubusercontent.com/assets/5982785/8150888/09ec19aa-12fc-11e5-8c03-da54e7b0c8ee.png)

