### PR TITLE
Remove href from disabled pagination links

### DIFF
--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -17,10 +17,10 @@ class PaginatorHelper extends \Cake\View\Helper\PaginatorHelper
         $this->_defaultConfig['templates'] = [
             'nextActive' => '<li class="next"><a rel="next" aria-label="Next" href="{{url}}">' .
                             '<span aria-hidden="true">{{text}}</span></a></li>',
-            'nextDisabled' => '<li class="next disabled"><a href=""><span aria-hidden="true">{{text}}</span></a></li>',
+            'nextDisabled' => '<li class="next disabled"><a><span aria-hidden="true">{{text}}</span></a></li>',
             'prevActive' => '<li class="prev"><a rel="prev" aria-label="Previous" href="{{url}}">' .
                             '<span aria-hidden="true">{{text}}</span></a></li>',
-            'prevDisabled' => '<li class="prev disabled"><a href=""><span aria-hidden="true">{{text}}</span></a></li>',
+            'prevDisabled' => '<li class="prev disabled"><a><span aria-hidden="true">{{text}}</span></a></li>',
             'current' => '<li class="active"><span>{{text}} <span class="sr-only">(current)</span></span></li>',
         ] + $this->_defaultConfig['templates'];
 

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -112,7 +112,7 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->numbers(['prev' => true, 'next' => true]);
         $expected = [
             'ul' => ['class' => 'pagination'],
-            ['li' => ['class' => 'prev disabled']], ['a' => ['href' => '']], ['span' => ['aria-hidden' => 'true']], '&laquo;', '/span', '/a', '/li',
+            ['li' => ['class' => 'prev disabled']], ['a' => []], ['span' => ['aria-hidden' => 'true']], '&laquo;', '/span', '/a', '/li',
             '<li', ['a' => ['href' => '/index?page=4']], '4', '/a', '/li',
             '<li', ['a' => ['href' => '/index?page=5']], '5', '/a', '/li',
             '<li', ['a' => ['href' => '/index?page=6']], '6', '/a', '/li',


### PR DESCRIPTION
On the first or last page of a paginated action, the disabled next/prev links were still clickable.

This change doesn't seem to affect styling. Also, having an empty `href` attribute is against Yslow's rules.

