### PR TITLE
Fix Red caption for textarea - not just for text

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -218,8 +218,8 @@ class FormHelper extends Helper
                 }
                 break;
             case 'multiselect':
-            case 'textarea':
                 break;
+            case 'textarea':
             default:
                 if ($options['label'] !== false && strpos($this->templates('label'), 'class=') === false) {
                     $options['label'] = $this->injectClasses('control-label', (array)$options['label']);


### PR DESCRIPTION
Textarea (maybe even others?) should also be handled like normal text input.
If the form invalidates the caption should also get the correct class.
Right now the class injection is skipped for all others than text which makes the form inconsistent in appearance.

The form I used had a custom label and that broke the injection here

     echo $this->Form->input('comment', ['label' => __('Text')]);