### PR TITLE
Enhancements to Flash Helper and Element

### DIFF
--- a/src/Template/Element/Flash/default.ctp
+++ b/src/Template/Element/Flash/default.ctp
@@ -1,6 +1,6 @@
 <?php
 $class = array_unique((array)$params['class']);
-$message = h($message);
+$message = (isset($params['escape']) && $params['escape'] === false) ? $message : h($message);
 
 if (in_array('alert-dismissible', $class)) {
     $button = <<<BUTTON

--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -21,7 +21,8 @@ class FlashHelper extends Helper
      */
     protected $_defaultConfig = [
         'class' => ['alert', 'alert-dismissible', 'fade', 'in'],
-        'attributes' => ['role' => 'alert']
+        'attributes' => ['role' => 'alert'],
+        'element' => 'BootstrapUI.Flash/default'
     ];
 
     /**
@@ -71,7 +72,7 @@ class FlashHelper extends Helper
                 if (is_array($message['params']['class'])) {
                     $message['params']['class'][] = 'alert-' . $class;
                 }
-                $element = 'BootstrapUI.Flash/default';
+                $element = $this->_config['element'];
             }
 
             $out .= $this->_View->element($element, $message);

--- a/tests/TestCase/View/Helper/FlashHelperTest.php
+++ b/tests/TestCase/View/Helper/FlashHelperTest.php
@@ -55,6 +55,12 @@ class FlashHelperTest extends TestCase
                     'element' => 'Flash/default',
                     'params' => ['class' => 'foobar']
                 ],
+                'custom3' => [
+                    'key' => 'custom3',
+                    'message' => 'This is <a href="#">custom3</a>',
+                    'element' => 'Flash/default',
+                    'params' => ['escape' => false]
+                ],
             ]
         ]);
     }
@@ -96,6 +102,9 @@ class FlashHelperTest extends TestCase
         $result = $this->Flash->render('custom2');
         $this->assertContains('<div role="alert" class="foobar">', $result);
         $this->assertContains('This is custom2', $result);
+
+        $result = $this->Flash->render('custom3');
+        $this->assertContains('This is <a href="#">custom3</a>', $result);
     }
 
     /**


### PR DESCRIPTION
Created a way a to not escape message content so thinks like links are not escaped. Works like most of CakePHP helper in that you must set escape to false, otherwise it escapes by default. 

```php
$this->Flash->success('<i class="fa fa-trash"></i> Your tag was trashed!', ['params' => ['escape' => false]]);
```

I also thought that sometimes you might need to do some additional customizations to the Flash Element that is used by default. So it would be nice to set the element when you load the helper.

```php
$this->loadHelper('BootstrapUI.Flash', ['element' => 'Flash/default']);
```  