### PR TITLE
Add ignore for pre-commit hook, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,10 +213,11 @@ their own that I can ignore when I pull)
 * Pull request - bonus point for topic branches
 
 To ensure your PRs are considered for upstream, you MUST follow the CakePHP coding standards. A `pre-commit`
-hook has been included to automatically run the code sniffs for you:
+hook has been included to automatically run the code sniffs for you. From your project's root directory:
 
 ```
-ln -s ../../contrib/pre-commit .git/hooks/.
+cp vendor/friendsofcake/bootstrap-ui/contrib/pre-commit .git/hooks/
+chmod 755 .git/hooks/pre-commit
 ```
 
 ## Bugs & Feedback

--- a/contrib/pre-commit
+++ b/contrib/pre-commit
@@ -15,7 +15,7 @@ SFILES=${SFILES:-$FILES}
 if [ "$FILES" != "" ]
 then
     echo "Running PHPCS"
-    ./vendor/bin/phpcs --standard=vendor/cakephp/cakephp-codesniffer/CakePHP $SFILES
+    ./vendor/bin/phpcs --standard=vendor/cakephp/cakephp-codesniffer/CakePHP --ignore=*/config/Migrations/* $SFILES
     if [ $? != 0 ]
     then
         echo "PHPCS Errors found; commit aborted."


### PR DESCRIPTION
If a commit includes baked migrations, a namespace error prevents the commit from proceeding:
```
Each class must be in a namespace of at least one level
```
This just ignores files in `config/Migrations`. It also updates the pre-commit hook installation instructions as symlinking it didn't work for me due to git not preserving executable permissions on the script. 