### PR TITLE
Unset class to avoid re-merging.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -156,7 +156,9 @@ class FormHelper extends Helper
         if (array_key_exists('class', $options)) {
             $optionsClass = is_array($options['class']) ? $options['class'] : explode(' ', $options['class']);
             $class = array_unique(array_merge($class, $optionsClass));
+            unset($options['class']);
         }
+
         $options = Hash::merge($options, ['class' => $class]);
 
         return parent::submit($caption, $options);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -987,6 +987,17 @@ class FormHelperTest extends TestCase
             ]
         ];
         $this->assertHtml($expected, $result);
+
+        $result = $this->Form->submit('Submit', ['class' => ['btn', 'btn-block']]);
+        $expected = [
+            'div' => ['class' => 'submit'],
+            'input' => [
+                'type' => 'submit',
+                'value' => 'Submit',
+                'class' => 'btn btn-block',
+            ]
+        ];
+        $this->assertHtml($expected, $result);
     }
 
     public function testStyledButton()


### PR DESCRIPTION
Without removing the array key, the result of Hash::merge() will contain the provided classes multiple times.

    <div class="submit"><input type="submit" class="btn-primary btn btn-primary" value="Foo"/></div>