### PR TITLE
Grid support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "friendsofcake/bootstrap-ui",
+    "name": "2km/bootstrap-ui",
     "description": "Twitter Bootstrap 3 support for CakePHP 3",
     "type": "cakephp-plugin",
     "keywords": ["cakephp", "twitter", "bootstrap"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "2km/bootstrap-ui",
+    "name": "friendsofcake/bootstrap-ui",
     "description": "Twitter Bootstrap 3 support for CakePHP 3",
     "type": "cakephp-plugin",
     "keywords": ["cakephp", "twitter", "bootstrap"],

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -5,6 +5,12 @@ class HtmlHelper extends \Cake\View\Helper\HtmlHelper
 {
     use OptionsAwareTrait;
 
+    private $grid = [];
+
+    private $gridOptions = [];
+
+    private $gridCounter = 0;
+
     /**
      * Returns Bootstrap badge markup. By default, uses `<SPAN>`.
      *
@@ -93,5 +99,71 @@ class HtmlHelper extends \Cake\View\Helper\HtmlHelper
         $tag = $options['tag'];
         unset($options['tag'], $options['type']);
         return $this->tag($tag, $text, $this->injectClasses($classes, $options));
+    }
+
+    /**
+     * Set the content of a cell in a Bootstrap's grid
+     *
+     * @param  string $text Text, or Html content will be insert in a cell of grid
+     * @return $this
+     */
+    public function gridContent($text = null)
+    {
+        $this->gridCounter++;
+
+        $this->grid[$this->gridCounter] = $text;
+
+        return $this;
+    }
+
+    /**
+     * Configure atribututes of a cell
+     *
+     * @param  array $options set the cell configuration
+     * @return $this
+     */
+    public function gridConfig($options = [])
+    {
+        $options += [
+            'type' => 'md',
+            'size' => 12,
+            'offset' => null, //['type'] => 'md', ['size'] => 12
+        ];
+
+        $this->gridOptions[$this->gridCounter][] = $options;
+
+        return $this;
+    }
+
+    /**
+     * Return html of all grid
+     *
+     * @return string $html of a Bootstrap grid
+     */
+    public function gridRender()
+    {
+        $html = '<div class="row">';
+        foreach ($this->grid as $key => $value) {
+            $class = null;
+            foreach ($this->gridOptions[$key] as $key2 => $config) {
+                if ($key2 > 0) {
+                    $class .= ' ';
+                }
+                $offset = null;
+                $class .= 'col-' . $config['type'] . '-' . $config['size'];
+                if (!empty($config['offset'])) {
+                    $offset .= 'col-' . $config['offset']['type'] . '-offset-' . $config['offset']['size'];
+                    $class .= ' ' . $offset;
+                }
+            }
+            if (empty($class)) {
+                $class = 'col-md-12';
+            }
+            $html .= '<div class="' . $class . '">' . $value . '</div>';
+        }
+        $html .= '</div>';
+        $this->gridCounter = 0;
+        $this->grid = $this->gridConfig = [];
+        return $html;
     }
 }

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -28,7 +28,7 @@ class HtmlHelperTest extends TestCase
         $expected = [
             'span' => ['class' => 'badge'],
             'foo',
-            '/span'
+            '/span',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -38,21 +38,21 @@ class HtmlHelperTest extends TestCase
         $result = $this->Html->icon('foo');
         $expected = [
             'i' => ['class' => 'glyphicon glyphicon-foo'],
-            '/i'
+            '/i',
         ];
         $this->assertHtml($expected, $result);
 
         $result = $this->Html->icon('foo', ['iconSet' => 'fa']);
         $expected = [
             'i' => ['class' => 'fa fa-foo'],
-            '/i'
+            '/i',
         ];
         $this->assertHtml($expected, $result);
 
         $result = $this->Html->icon('foo', ['tag' => 'span']);
         $expected = [
             'span' => ['class' => 'glyphicon glyphicon-foo'],
-            '/span'
+            '/span',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -63,7 +63,7 @@ class HtmlHelperTest extends TestCase
         $expected = [
             'span' => ['class' => 'label label-default'],
             'foo',
-            '/span'
+            '/span',
         ];
         $this->assertHtml($expected, $result);
 
@@ -71,7 +71,7 @@ class HtmlHelperTest extends TestCase
         $expected = [
             'span' => ['class' => 'label label-warning'],
             'foo',
-            '/span'
+            '/span',
         ];
         $this->assertHtml($expected, $result);
 
@@ -79,7 +79,7 @@ class HtmlHelperTest extends TestCase
         $expected = [
             'span' => ['class' => 'label label-custom'],
             'foo',
-            '/span'
+            '/span',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -103,8 +103,33 @@ class HtmlHelperTest extends TestCase
             ['li' => ['class' => 'last']],
             'joe',
             '/li',
-            '/ul'
+            '/ul',
         ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testGrid()
+    {
+        $result = $this->Html
+            ->gridContent('test 1')
+            ->gridConfig(['size' => 3])
+            ->gridConfig(['type' => 'xs', 'size' => 12])
+            ->gridContent('test 2')
+            ->gridConfig(['size' => 9])
+            ->gridConfig(['type' => 'xs', 'size' => 12])
+            ->gridRender();
+
+        $expected = [
+            'div' => ['class' => 'row'],
+            ['div' => ['class' => 'col-md-3 col-xs-12']],
+            'test 1',
+            '/div',
+            ['div' => ['class' => 'col-md-9 col-xs-12']],
+            'test 2',
+            '/div',
+            '/div',
+        ];
+
         $this->assertHtml($expected, $result);
     }
 }


### PR DESCRIPTION
Added methods to generate Bootstrap grid.

Code example:
```php
echo $this->Html->gridContent($this->Form->input('field1'))
    ->gridConfig(['size' => 4])
    ->gridContent($this->Form->input('field2'))
    ->gridConfig(['size' => 4])
    ->gridContent($this->Form->input('field3'))
    ->gridConfig(['size' => 4])
    ->gridRender();
```