### PR TITLE
input templates fix

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -191,6 +191,14 @@ class FormHelper extends Helper
         $options = $this->_parseOptions($fieldName, $options);
         $reset = $this->templates();
 
+        $templater = $this->templater();
+        if (!empty($options['templates'])) {
+            $templater->push();
+            $templateMethod = is_string($options['templates']) ? 'load' : 'add';
+            $templater->{$templateMethod}($options['templates']);
+        }
+        unset($options['templates']);
+
         switch ($options['type']) {
             case 'checkbox':
                 if (!isset($options['inline'])) {


### PR DESCRIPTION
Fix to allow templates to be passed in for inputs.  Currently there appears to be no way to change templates on the fly for an input.  Cake's Form Helper takes care of this but there was no way to pass the templates to the bootstrap UI and have them be used. 