### PR TITLE
Fix inability to override templates through FormHelper::input() options.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -189,7 +189,14 @@ class FormHelper extends Helper
             'templateVars' => []
         ];
         $options = $this->_parseOptions($fieldName, $options);
-        $reset = $this->templates();
+
+        $newTemplates = $options['templates'];
+        if ($newTemplates) {
+            $this->templater()->push();
+            $templateMethod = is_string($options['templates']) ? 'load' : 'add';
+            $this->templater()->{$templateMethod}($options['templates']);
+            $options['templates'] = [];
+        }
 
         switch ($options['type']) {
             case 'checkbox':
@@ -203,22 +210,16 @@ class FormHelper extends Helper
                 break;
             case 'radio':
                 $isInline = (isset($options['inline']) && $options['inline'] === true);
-
-                $templates = [];
                 if ($isInline && $this->_align !== 'horizontal') {
-                    $templates['formGroup'] = $this->templater()->get('radioInlineFormGroup');
+                    $options['templates']['formGroup'] = $this->templater()->get('radioInlineFormGroup');
                 }
                 if (!$isInline) {
-                    $templates['nestingLabel'] = $this->templater()->get('radioNestingLabel');
+                    $options['templates']['nestingLabel'] = $this->templater()->get('radioNestingLabel');
                 }
-
-                $this->templater()->add($templates);
                 break;
             case 'select':
                 if (isset($options['multiple']) && $options['multiple'] === 'checkbox') {
-                    $this->templater()->add([
-                        'checkboxWrapper' => $this->templater()->get('multipleCheckboxWrapper')
-                    ]);
+                    $options['templates']['checkboxWrapper'] = $this->templater()->get('multipleCheckboxWrapper');
                     $options['type'] = 'multicheckbox';
                 }
                 break;
@@ -243,7 +244,9 @@ class FormHelper extends Helper
         }
 
         $result = parent::input($fieldName, $options);
-        $this->templates($reset);
+        if ($newTemplates) {
+            $this->templater()->pop();
+        }
         return $result;
     }
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -656,6 +656,62 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
     }
 
+    /**
+     * https://github.com/FriendsOfCake/bootstrap-ui/pull/113
+     *
+     * @return void
+     */
+    public function testRadioInputCustomTemplate()
+    {
+        $templates = [
+            'radioNestingLabel' => '<div class="radio custom-class">{{hidden}}<label{{attrs}}>{{input}}{{text}}</label></div>',
+        ];
+
+        $this->Form->create($this->article);
+
+        $result = $this->Form->input('published', [
+            'type' => 'radio',
+            'options' => ['Yes', 'No'],
+            'templates' => $templates
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group radio']],
+            ['label' => true],
+            'Published',
+            '/label',
+            ['input' => [
+                'type' => 'hidden',
+                'name' => 'published',
+                'value' => '',
+            ]],
+            ['div' => ['class' => 'radio custom-class']],
+            ['label' => ['for' => 'published-0']],
+            ['input' => [
+                'type' => 'radio',
+                'name' => 'published',
+                'value' => 0,
+                'id' => 'published-0',
+            ]],
+            'Yes',
+            '/label',
+            '/div',
+            ['div' => ['class' => 'radio custom-class']],
+            ['label' => ['for' => 'published-1']],
+            ['input' => [
+                'type' => 'radio',
+                'name' => 'published',
+                'value' => 1,
+                'id' => 'published-1',
+            ]],
+            'No',
+            '/label',
+            '/div',
+            '/div'
+        ];
+
+        $this->assertHtml($expected, $result);
+    }
+
     public function testBasicCheckboxInput()
     {
         $this->Form->create($this->article);
@@ -1133,6 +1189,32 @@ class FormHelperTest extends TestCase
             'error message',
             '/div',
             ['div' => ['class' => 'help-block']],
+            'help text',
+            '/div',
+            '/div'
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Form->input('title', [
+            'help' => 'help text',
+            'templates' => ['help' => '<div class="custom-help-block">{{content}}</div>']
+        ]);
+        $expected = [
+            'div' => ['class' => 'form-group text required has-error'],
+            'label' => ['class' => 'control-label', 'for' => 'title'],
+            'Title',
+            '/label',
+            'input' => [
+                'type' => 'text',
+                'name' => 'title',
+                'id' => 'title',
+                'class' => 'form-control ',
+                'required' => 'required'
+            ],
+            ['div' => ['class' => 'help-block']],
+            'error message',
+            '/div',
+            ['div' => ['class' => 'custom-help-block']],
             'help text',
             '/div',
             '/div'


### PR DESCRIPTION
Closes #113

@jrble819 @darensipes Please try out this patch (use "dev-issue-113" through composer) and confirm it resolves your issue.