### PR TITLE
Fixing the reset of the templates

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -189,6 +189,7 @@ class FormHelper extends Helper
             'templateVars' => []
         ];
         $options = $this->_parseOptions($fieldName, $options);
+        $reset = $this->templates();
 
         $newTemplates = $options['templates'];
         if ($newTemplates) {
@@ -244,9 +245,8 @@ class FormHelper extends Helper
         }
 
         $result = parent::input($fieldName, $options);
-        if ($newTemplates) {
-            $this->templater()->pop();
-        }
+        $this->templates($reset);
+
         return $result;
     }
 


### PR DESCRIPTION
Need to reset the templates otherwise when calling successive inputs with ```prepend``` option you get multiple appended HTML on subsequent inputs. It could possibly be affecting other options.

Example:
```php
<?= $this->Form->input('username', ['label' => 'Username or Email', 'prepend' => '<i class="fa fa-at"></i>', 'autocomplete' => 'off']) ?>
<?= $this->Form->input('password', ['prepend' => '<i class="fa fa-key"></i>', 'autocomplete' => 'off']) ?>
```


<img width="504" alt="screen shot 2016-02-08 at 12 15 05 pm" src="https://cloud.githubusercontent.com/assets/840593/12893189/c737e954-ce5d-11e5-979b-f7f8795b821b.png">


