### PR TITLE
support for multiple classes in a string

### DIFF
--- a/src/Template/Element/Flash/default.ctp
+++ b/src/Template/Element/Flash/default.ctp
@@ -2,7 +2,7 @@
 $class = array_unique((array)$params['class']);
 $message = (isset($params['escape']) && $params['escape'] === false) ? $message : h($message);
 
-if (in_array('alert-dismissible', $class)) {
+if (in_array('alert-dismissible', $class) || strpos($class, 'alert-dismissible') !== false) {
     $button = <<<BUTTON
 <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
 BUTTON;


### PR DESCRIPTION
I gotta believe most people write their classes as a string instead of an array.  This little change just adds a check to see if someone put in an alternative way to name classes.  eg.  ["params" => ["class" => "alert alert danger alert-dismissible"]], where as now (without this change you have to put each class as a separate array element. eg.  ["params" => ["class" => ["alert", "alert-danger", "alert-dismissible"]]]