### PR TITLE
out of the box alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ composer require friendsofcake/bootstrap-ui
 Then load the plugin by adding the following to your app's `config/boostrap.php`:
 
 ```php
-\Cake\Core\Plugin::load('BootstrapUI');
+\Cake\Core\Plugin::load('BootstrapUI', ['bootstrap' => true]);
 ```
 
 or using CakePHP's console:

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+
+use Cake\Core\Configure;
+
+Configure::write('Auth.flash.params.class', ['alert', 'alert-danger', 'alert-dismissible']);


### PR DESCRIPTION
Not sure if it's just because I'm working with the cakedc/users plugin, but auth alerts were not working out of the box.  This update makes auth alerts work out of the box and/or play nice with the cakedc/users plugin with no downside that I can think of. 