### PR TITLE
small fixes for unit tests

### DIFF
--- a/tests/TestCase/View/Helper/FlashHelperTest.php
+++ b/tests/TestCase/View/Helper/FlashHelperTest.php
@@ -3,7 +3,6 @@
 namespace BootstrapUI\Test\TestCase\View\Helper;
 
 use BootstrapUI\View\Helper\FlashHelper;
-use Cake\Controller\Controller;
 use Cake\Network\Request;
 use Cake\Network\Session;
 use Cake\TestSuite\TestCase;
@@ -15,6 +14,15 @@ use Cake\View\View;
  */
 class FlashHelperTest extends TestCase
 {
+    /**
+     * @var View
+     */
+    private $View;
+
+    /**
+     * @var FlashHelper
+     */
+    private $Flash;
 
     /**
      * setUp method

--- a/tests/TestCase/View/Helper/FlashHelperTest.php
+++ b/tests/TestCase/View/Helper/FlashHelperTest.php
@@ -17,12 +17,12 @@ class FlashHelperTest extends TestCase
     /**
      * @var View
      */
-    private $View;
+    public $View;
 
     /**
      * @var FlashHelper
      */
-    private $Flash;
+    public $Flash;
 
     /**
      * setUp method

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -13,6 +13,21 @@ use Cake\View\View;
 
 class FormHelperTest extends TestCase
 {
+    /**
+     * @var View
+     */
+    private $View;
+
+    /**
+     * @var FormHelper
+     */
+    private $Form;
+
+    /**
+     * @var array
+     */
+    private $article;
+
     public function setUp()
     {
         parent::setUp();
@@ -338,7 +353,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
     }
 
-    public function testAddonPrependedInput()
+    public function testAddOnPrependedInput()
     {
         $this->Form->create($this->article);
 
@@ -386,7 +401,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
     }
 
-    public function testAddonAppendedInput()
+    public function testAddOnAppendedInput()
     {
         $this->Form->create($this->article);
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -16,17 +16,17 @@ class FormHelperTest extends TestCase
     /**
      * @var View
      */
-    private $View;
+    public $View;
 
     /**
      * @var FormHelper
      */
-    private $Form;
+    public $Form;
 
     /**
      * @var array
      */
-    private $article;
+    public $article;
 
     public function setUp()
     {

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -8,6 +8,16 @@ use Cake\View\View;
 
 class HtmlHelperTest extends TestCase
 {
+    /**
+     * @var View
+     */
+    private $View;
+
+    /**
+     * @var HtmlHelper
+     */
+    private $Html;
+
     public function setUp()
     {
         parent::setUp();

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -11,12 +11,12 @@ class HtmlHelperTest extends TestCase
     /**
      * @var View
      */
-    private $View;
+    public $View;
 
     /**
      * @var HtmlHelper
      */
-    private $Html;
+    public $Html;
 
     public function setUp()
     {

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -26,6 +26,11 @@ class PaginatorHelperTest extends TestCase
     public $Paginator;
 
     /**
+     * @var string
+     */
+    public $locale;
+
+    /**
      * setUp method
      *
      * @return void
@@ -59,7 +64,6 @@ class PaginatorHelperTest extends TestCase
         Router::connect('/:controller/:action/*');
         Router::connect('/:plugin/:controller/:action/*');
 
-        // @todo Set locale for unit test without using private property.
         $this->locale = I18n::locale();
     }
 

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -18,12 +18,12 @@ class PaginatorHelperTest extends TestCase
     /**
      * @var View
      */
-    private $View;
+    public $View;
 
     /**
      * @var PaginatorHelper
      */
-    private $Paginator;
+    public $Paginator;
 
     /**
      * setUp method

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -15,6 +15,15 @@ use Cake\View\View;
  */
 class PaginatorHelperTest extends TestCase
 {
+    /**
+     * @var View
+     */
+    private $View;
+
+    /**
+     * @var PaginatorHelper
+     */
+    private $Paginator;
 
     /**
      * setUp method
@@ -50,6 +59,7 @@ class PaginatorHelperTest extends TestCase
         Router::connect('/:controller/:action/*');
         Router::connect('/:plugin/:controller/:action/*');
 
+        // @todo Set locale for unit test without using private property.
         $this->locale = I18n::locale();
     }
 

--- a/tests/TestCase/View/UIViewTest.php
+++ b/tests/TestCase/View/UIViewTest.php
@@ -9,7 +9,7 @@ class UIViewTest extends TestCase
     /**
      * @var UIView
      */
-    private $View;
+    public $View;
 
     /**
      * setUp method

--- a/tests/TestCase/View/UIViewTest.php
+++ b/tests/TestCase/View/UIViewTest.php
@@ -7,6 +7,11 @@ use Cake\TestSuite\TestCase;
 class UIViewTest extends TestCase
 {
     /**
+     * @var UIView
+     */
+    private $View;
+
+    /**
      * setUp method
      *
      * @return void

--- a/tests/TestCase/View/UIViewTraitTest.php
+++ b/tests/TestCase/View/UIViewTraitTest.php
@@ -10,6 +10,11 @@ class UIViewTraitTest extends TestCase
     use UIViewTrait;
 
     /**
+     * @var UIView
+     */
+    private $View;
+
+    /**
      * setUp method
      *
      * @return void
@@ -71,6 +76,7 @@ class UIViewTraitTest extends TestCase
         $cell = $this->View->cell('Articles');
 
         $this->assertEquals('display', $cell->template);
-        $this->assertEquals("articles cell display\n", "{$cell}");
+        // 2016-03-28: used trim() to remove LF. assert was failing on Windows.
+        $this->assertEquals("articles cell display", trim($cell));
     }
 }

--- a/tests/TestCase/View/UIViewTraitTest.php
+++ b/tests/TestCase/View/UIViewTraitTest.php
@@ -12,7 +12,7 @@ class UIViewTraitTest extends TestCase
     /**
      * @var UIView
      */
-    private $View;
+    public $View;
 
     /**
      * setUp method

--- a/tests/test_app/TestApp/View/Cell/ArticlesCell.php
+++ b/tests/test_app/TestApp/View/Cell/ArticlesCell.php
@@ -1,7 +1,9 @@
 <?php
 namespace TestApp\View\Cell;
 
-class ArticlesCell extends \Cake\View\Cell
+use Cake\View\Cell;
+
+class ArticlesCell extends Cell
 {
 
     /**


### PR DESCRIPTION
One of the tests were failing for me on Windows (stupid line feeds).

While looking at the unit tests. PhpStorm was flagging various things with warnings. So I added definitions for private properties and fix a couple of grammars.

I noticed that there aren't any units for the widgets. Can widgets be tested? How would that be done?