### PR TITLE
added button tests and support for btn-default as a default style.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,9 @@
         "cakephp/cakephp": "~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.1.*"
+        "phpunit/phpunit": "4.1.*",
+        "squizlabs/php_codesniffer": "2.*",
+        "cakephp/cakephp-codesniffer": "dev-master"
     },
     "support": {
         "issues": "http://github.com/friendsofcake/bootstrap-ui/issues",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "4.1.*",
-        "squizlabs/php_codesniffer": "2.*",
         "cakephp/cakephp-codesniffer": "dev-master"
     },
     "support": {

--- a/contrib/pre-commit
+++ b/contrib/pre-commit
@@ -1,5 +1,6 @@
 #!/bin/sh
 FILES=`git diff --cached --name-only --diff-filter=ACMR HEAD | grep \\\\.php`
+PROJECT=`php -r "echo dirname(dirname(realpath('$0')));"`
 
 # Determine if a file list is passed
 if [ "$#" -eq 1 ]
@@ -12,10 +13,22 @@ then
 fi
 SFILES=${SFILES:-$FILES}
 
-if [ "$FILES" != "" ]
+echo "Checking PHP Lint..."
+for FILE in $SFILES
+do
+    php -l -d display_errors=0 $PROJECT/$FILE
+    if [ $? != 0 ]
+    then
+        echo "Fix the error before commit."
+        exit 1
+    fi
+    FILES="$FILES $PROJECT/$FILE"
+done
+
+if [ "$SFILES" != "" ]
 then
     echo "Running PHPCS"
-    ./vendor/bin/phpcs --standard=vendor/cakephp/cakephp-codesniffer/CakePHP --ignore=*/config/Migrations/* $SFILES
+    ./vendor/bin/phpcs --standard=vendor/cakephp/cakephp-codesniffer/CakePHP $SFILES
     if [ $? != 0 ]
     then
         echo "PHPCS Errors found; commit aborted."

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2,6 +2,7 @@
 
 namespace BootstrapUI\View\Helper;
 
+use BootstrapUI\View\Widget\ButtonWidget;
 use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\Utility\Hash;
 use Cake\View\Helper\FormHelper as Helper;
@@ -160,8 +161,8 @@ class FormHelper extends Helper
             $class = array_unique(array_merge($class, $optionsClass));
             unset($options['class']);
         }
-
         $options = Hash::merge($options, ['class' => $class]);
+        $options['class'] = ButtonWidget::applyStyle($options['class']);
 
         return parent::submit($caption, $options);
     }

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -155,15 +155,7 @@ class FormHelper extends Helper
      */
     public function submit($caption = null, array $options = [])
     {
-        $class = ['btn'];
-        if (array_key_exists('class', $options)) {
-            $optionsClass = is_array($options['class']) ? $options['class'] : explode(' ', $options['class']);
-            $class = array_unique(array_merge($class, $optionsClass));
-            unset($options['class']);
-        }
-        $options = Hash::merge($options, ['class' => $class]);
-        $options['class'] = $this->applyStyle($options['class']);
-
+        $options = $this->applyButtonStyles($options);
         return parent::submit($caption, $options);
     }
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -154,7 +154,7 @@ class FormHelper extends Helper
      */
     public function submit($caption = null, array $options = [])
     {
-        $options = $this->applyButtonStyles($options);
+        $options = $this->applyButtonClasses($options);
         return parent::submit($caption, $options);
     }
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -162,7 +162,7 @@ class FormHelper extends Helper
             unset($options['class']);
         }
         $options = Hash::merge($options, ['class' => $class]);
-        $options['class'] = ButtonWidget::applyStyle($options['class']);
+        $options['class'] = $this->applyStyle($options['class']);
 
         return parent::submit($caption, $options);
     }

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2,7 +2,6 @@
 
 namespace BootstrapUI\View\Helper;
 
-use BootstrapUI\View\Widget\ButtonWidget;
 use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\Utility\Hash;
 use Cake\View\Helper\FormHelper as Helper;

--- a/src/View/Helper/OptionsAwareTrait.php
+++ b/src/View/Helper/OptionsAwareTrait.php
@@ -38,7 +38,7 @@ trait OptionsAwareTrait
      * @param array $data An array of HTML attributes and options.
      * @return array An array of HTML attributes and options.
      */
-    public function applyButtonStyles(array $data)
+    public function applyButtonClasses(array $data)
     {
         if ($this->hasAnyClass($this->buttonClasses, $data)) {
             $data = $this->injectClasses('btn', $data);

--- a/src/View/Helper/OptionsAwareTrait.php
+++ b/src/View/Helper/OptionsAwareTrait.php
@@ -4,6 +4,39 @@ namespace BootstrapUI\View\Helper;
 
 trait OptionsAwareTrait
 {
+    protected static $_styles = [
+        'default', 'btn-default',
+        'success', 'btn-success',
+        'warning', 'btn-warning',
+        'danger', 'btn-danger',
+        'info', 'btn-info',
+        'primary', 'btn-primary'
+    ];
+
+    /**
+     * Applies the button CSS styles for an array of CSS classes.
+     *
+     * @param array $classes A list of CSS classes.
+     * @return string
+     */
+    public static function applyStyle(array $classes)
+    {
+        $default = true;
+        foreach ($classes as &$class) {
+            if (in_array($class, self::$_styles)) {
+                if (strpos($class, 'btn-') !== 0) {
+                    $class = 'btn-' . $class;
+                }
+                $default = false;
+                break;
+            }
+        }
+        if ($default) {
+            $classes[] = 'btn-default';
+        }
+        return implode(' ', $classes);
+    }
+
     /**
      * Injects classes into `$options['class']` when they don't already exist.
      *

--- a/src/View/Helper/OptionsAwareTrait.php
+++ b/src/View/Helper/OptionsAwareTrait.php
@@ -9,7 +9,7 @@ trait OptionsAwareTrait
      *
      * @var array
      */
-    public $ButtonStyles = [
+    public $buttonClasses = [
         'default', 'btn-default',
         'success', 'btn-success',
         'warning', 'btn-warning',
@@ -23,7 +23,7 @@ trait OptionsAwareTrait
      *
      * @var array
      */
-    public $ButtonStyleAliases = [
+    public $buttonClassAliases = [
         'default' => 'btn-default',
         'success' => 'btn-success',
         'warning' => 'btn-warning',
@@ -40,12 +40,12 @@ trait OptionsAwareTrait
      */
     public function applyButtonStyles(array $data)
     {
-        if ($this->hasAnyClass($this->ButtonStyles, $data)) {
+        if ($this->hasAnyClass($this->buttonClasses, $data)) {
             $data = $this->injectClasses('btn', $data);
         } else {
             $data = $this->injectClasses('btn btn-default', $data);
         }
-        return $this->renameClasses($this->ButtonStyleAliases, $data);
+        return $this->renameClasses($this->buttonClassAliases, $data);
     }
 
     /**

--- a/src/View/Helper/OptionsAwareTrait.php
+++ b/src/View/Helper/OptionsAwareTrait.php
@@ -4,7 +4,12 @@ namespace BootstrapUI\View\Helper;
 
 trait OptionsAwareTrait
 {
-    protected static $_styles = [
+    /**
+     * A list of allowed styles for buttons.
+     *
+     * @var array
+     */
+    public $ButtonStyles = [
         'default', 'btn-default',
         'success', 'btn-success',
         'warning', 'btn-warning',
@@ -14,31 +19,82 @@ trait OptionsAwareTrait
     ];
 
     /**
-     * Applies the button CSS styles for an array of CSS classes.
+     * A mapping of aliases for button styles.
      *
-     * @param array $classes A list of CSS classes.
-     * @return string
+     * @var array
      */
-    public static function applyStyle(array $classes)
+    public $ButtonStyleAliases = [
+        'default' => 'btn-default',
+        'success' => 'btn-success',
+        'warning' => 'btn-warning',
+        'danger' => 'btn-danger',
+        'info' => 'btn-info',
+        'primary' => 'btn-primary'
+    ];
+
+    /**
+     * Contains the logic for applying style classes for buttons.
+     *
+     * @param array $data An array of HTML attributes and options.
+     * @return array An array of HTML attributes and options.
+     */
+    public function applyButtonStyles(array $data)
     {
-        $default = true;
-        foreach ($classes as &$class) {
-            if (in_array($class, self::$_styles)) {
-                if (strpos($class, 'btn-') !== 0) {
-                    $class = 'btn-' . $class;
-                }
-                $default = false;
-                break;
-            }
+        if ($this->hasAnyClass($this->ButtonStyles, $data)) {
+            $data = $this->injectClasses('btn', $data);
+        } else {
+            $data = $this->injectClasses('btn btn-default', $data);
         }
-        if ($default) {
-            $classes[] = 'btn-default';
-        }
-        return implode(' ', $classes);
+        return $this->renameClasses($this->ButtonStyleAliases, $data);
     }
 
     /**
-     * Injects classes into `$options['class']` when they don't already exist.
+     * Renames any CSS classes found in the options.
+     *
+     * @param array $classMap Key/Value pair of class(es) to be renamed.
+     * @param array $options An array of HTML attributes and options.
+     * @return array An array of HTML attributes and options.
+     */
+    public function renameClasses(array $classMap, array $options)
+    {
+        $options += ['class' => []];
+        $options['class'] = $this->_toClassArray($options['class']);
+        $classes = [];
+        foreach ($options['class'] as $name) {
+            $classes[] = array_key_exists($name, $classMap)
+                ? $classMap[$name]
+                : $name;
+        }
+        $options['class'] = trim(implode(' ', $classes));
+        return $options;
+    }
+
+    /**
+     * Checks if `$options['class']` contains any one of the class names.
+     *
+     * @param array|string $classes Name of class(es) to check.
+     * @param array $options An array of HTML attributes and options.
+     * @return bool True if any one of the class names was found.
+     */
+    public function hasAnyClass($classes, array $options)
+    {
+        $options += ['class' => []];
+
+        $options['class'] = $this->_toClassArray($options['class']);
+        $classes = $this->_toClassArray($classes);
+
+        foreach ($classes as $class) {
+            if (in_array($class, $options['class'])) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Injects classes into `$options['class']` when they don't already exist. If a class is defined
+     * in `$options['skip']` then it will not be injected. This method removes `$options['skip']` before
+     * returning.
      *
      * @param array|string $classes Name of class(es) to inject.
      * @param array $options An array of HTML attributes and options.

--- a/src/View/Widget/ButtonWidget.php
+++ b/src/View/Widget/ButtonWidget.php
@@ -20,9 +20,9 @@ class ButtonWidget extends \Cake\View\Widget\ButtonWidget
     ];
 
     /**
-     * Applies the button CSS styles for an array of CSS classnames.
+     * Applies the button CSS styles for an array of CSS classes.
      *
-     * @param array $classes
+     * @param array $classes A list of CSS classes.
      * @return string
      */
     public static function applyStyle(array $classes)

--- a/src/View/Widget/ButtonWidget.php
+++ b/src/View/Widget/ButtonWidget.php
@@ -10,6 +10,21 @@ class ButtonWidget extends \Cake\View\Widget\ButtonWidget
 
     use OptionsAwareTrait;
 
+
+    /**
+     * @var array
+     * @deprecated This property is no longer used.
+     * @see OptionsAwareTrait::applyButtonStyles
+     */
+    protected $_styles = [
+        'default',
+        'success',
+        'warning',
+        'danger',
+        'info',
+        'primary'
+    ];
+
     /**
      * Renders a button.
      *

--- a/src/View/Widget/ButtonWidget.php
+++ b/src/View/Widget/ButtonWidget.php
@@ -19,8 +19,7 @@ class ButtonWidget extends \Cake\View\Widget\ButtonWidget
      */
     public function render(array $data, ContextInterface $context)
     {
-        $data = $this->injectClasses('btn', $data);
-        $data['class'] = $this->applyStyle(explode(' ', $data['class']));
+        $data = $this->applyButtonStyles($data);
         return parent::render($data, $context);
     }
 }

--- a/src/View/Widget/ButtonWidget.php
+++ b/src/View/Widget/ButtonWidget.php
@@ -34,7 +34,7 @@ class ButtonWidget extends \Cake\View\Widget\ButtonWidget
      */
     public function render(array $data, ContextInterface $context)
     {
-        $data = $this->applyButtonStyles($data);
+        $data = $this->applyButtonClasses($data);
         return parent::render($data, $context);
     }
 }

--- a/src/View/Widget/ButtonWidget.php
+++ b/src/View/Widget/ButtonWidget.php
@@ -25,18 +25,19 @@ class ButtonWidget extends \Cake\View\Widget\ButtonWidget
      * @param array $classes
      * @return string
      */
-    public static function applyStyle(array $classes) {
+    public static function applyStyle(array $classes)
+    {
         $default = true;
         foreach ($classes as &$class) {
             if (in_array($class, self::$_styles)) {
-                if(strpos($class, 'btn-') !== 0) {
+                if (strpos($class, 'btn-') !== 0) {
                     $class = 'btn-' . $class;
                 }
                 $default = false;
                 break;
             }
         }
-        if($default) {
+        if ($default) {
             $classes[] = 'btn-default';
         }
         return implode(' ', $classes);

--- a/src/View/Widget/ButtonWidget.php
+++ b/src/View/Widget/ButtonWidget.php
@@ -10,39 +10,6 @@ class ButtonWidget extends \Cake\View\Widget\ButtonWidget
 
     use OptionsAwareTrait;
 
-    protected static $_styles = [
-        'default', 'btn-default',
-        'success', 'btn-success',
-        'warning', 'btn-warning',
-        'danger', 'btn-danger',
-        'info', 'btn-info',
-        'primary', 'btn-primary'
-    ];
-
-    /**
-     * Applies the button CSS styles for an array of CSS classes.
-     *
-     * @param array $classes A list of CSS classes.
-     * @return string
-     */
-    public static function applyStyle(array $classes)
-    {
-        $default = true;
-        foreach ($classes as &$class) {
-            if (in_array($class, self::$_styles)) {
-                if (strpos($class, 'btn-') !== 0) {
-                    $class = 'btn-' . $class;
-                }
-                $default = false;
-                break;
-            }
-        }
-        if ($default) {
-            $classes[] = 'btn-default';
-        }
-        return implode(' ', $classes);
-    }
-
     /**
      * Renders a button.
      *
@@ -53,7 +20,7 @@ class ButtonWidget extends \Cake\View\Widget\ButtonWidget
     public function render(array $data, ContextInterface $context)
     {
         $data = $this->injectClasses('btn', $data);
-        $data['class'] = self::applyStyle(explode(' ', $data['class']));
+        $data['class'] = $this->applyStyle(explode(' ', $data['class']));
         return parent::render($data, $context);
     }
 }

--- a/src/View/Widget/ButtonWidget.php
+++ b/src/View/Widget/ButtonWidget.php
@@ -10,14 +10,37 @@ class ButtonWidget extends \Cake\View\Widget\ButtonWidget
 
     use OptionsAwareTrait;
 
-    protected $_styles = [
-        'default',
-        'success',
-        'warning',
-        'danger',
-        'info',
-        'primary'
+    protected static $_styles = [
+        'default', 'btn-default',
+        'success', 'btn-success',
+        'warning', 'btn-warning',
+        'danger', 'btn-danger',
+        'info', 'btn-info',
+        'primary', 'btn-primary'
     ];
+
+    /**
+     * Applies the button CSS styles for an array of CSS classnames.
+     *
+     * @param array $classes
+     * @return string
+     */
+    public static function applyStyle(array $classes) {
+        $default = true;
+        foreach ($classes as &$class) {
+            if (in_array($class, self::$_styles)) {
+                if(strpos($class, 'btn-') !== 0) {
+                    $class = 'btn-' . $class;
+                }
+                $default = false;
+                break;
+            }
+        }
+        if($default) {
+            $classes[] = 'btn-default';
+        }
+        return implode(' ', $classes);
+    }
 
     /**
      * Renders a button.
@@ -29,16 +52,7 @@ class ButtonWidget extends \Cake\View\Widget\ButtonWidget
     public function render(array $data, ContextInterface $context)
     {
         $data = $this->injectClasses('btn', $data);
-        $data['class'] = explode(' ', $data['class']);
-
-        foreach ($data['class'] as &$class) {
-            if (in_array($class, $this->_styles)) {
-                $class = 'btn-' . $class;
-                break;
-            }
-        }
-
-        $data['class'] = implode(' ', $data['class']);
+        $data['class'] = self::applyStyle(explode(' ', $data['class']));
         return parent::render($data, $context);
     }
 }

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -425,7 +425,7 @@ class FormHelperTest extends TestCase
             '/label',
             ['div' => ['class' => 'input-group']],
             'span' => ['class' => 'input-group-btn'],
-            'button' => ['type' => 'submit', 'class' => 'btn'],
+            'button' => ['type' => 'submit', 'class' => 'btn btn-default'],
             'GO',
             '/button',
             '/span',
@@ -461,7 +461,7 @@ class FormHelperTest extends TestCase
                 'required' => 'required'
             ],
             'span' => ['class' => 'input-group-btn'],
-            'button' => ['type' => 'submit', 'class' => 'btn'],
+            'button' => ['type' => 'submit', 'class' => 'btn btn-default'],
             'GO',
             '/button',
             '/span',
@@ -1031,7 +1031,7 @@ class FormHelperTest extends TestCase
     {
         $result = $this->Form->button('Submit');
         $expected = [
-            'button' => ['class' => 'btn', 'type' => 'submit'],
+            'button' => ['class' => 'btn btn-default', 'type' => 'submit'],
             'Submit',
             '/button'
         ];
@@ -1046,7 +1046,7 @@ class FormHelperTest extends TestCase
             'input' => [
                 'type' => 'submit',
                 'value' => 'Submit',
-                'class' => 'btn',
+                'class' => 'btn btn-default',
             ]
         ];
         $this->assertHtml($expected, $result);
@@ -1060,7 +1060,7 @@ class FormHelperTest extends TestCase
             'input' => [
                 'type' => 'submit',
                 'value' => 'Submit',
-                'class' => 'btn btn-block',
+                'class' => 'btn btn-block btn-default',
             ]
         ];
         $this->assertHtml($expected, $result);
@@ -1071,7 +1071,7 @@ class FormHelperTest extends TestCase
             'input' => [
                 'type' => 'submit',
                 'value' => 'Submit',
-                'class' => 'btn btn-block',
+                'class' => 'btn btn-block btn-default',
             ]
         ];
         $this->assertHtml($expected, $result);

--- a/tests/TestCase/View/Helper/OptionsAwareTraitTest.php
+++ b/tests/TestCase/View/Helper/OptionsAwareTraitTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace BootstrapUI\Test\TestCase\View\Helper;
+
+use BootstrapUI\View\Helper\OptionsAwareTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * TestOptionsAware
+ */
+class TestOptionsAware
+{
+
+    use OptionsAwareTrait;
+}
+
+/**
+ * OptionsAwareTraitTest
+ */
+class OptionsAwareTraitTest extends TestCase
+{
+    /**
+     * @var OptionsAwareTrait
+     */
+    public $object;
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->object = new TestOptionsAware();
+    }
+
+    public function testApplyButtonStyles()
+    {
+        $this->assertEquals(['class' => 'btn btn-default'], $this->object->applyButtonStyles([]));
+        foreach (['default', 'success', 'warning', 'danger', 'info', 'primary'] as $style) {
+            $this->assertEquals(['class' => "btn-{$style} btn"], $this->object->applyButtonStyles(['class' => $style]));
+            $this->assertEquals(['class' => "btn-{$style} btn"], $this->object->applyButtonStyles(['class' => "btn-$style"]));
+        }
+    }
+
+    public function testRenameClasses()
+    {
+        $this->assertEquals(['class' => ''], $this->object->renameClasses(['a' => 'b'], []));
+        $this->assertEquals(['class' => 'b'], $this->object->renameClasses(['a' => 'b'], ['class' => 'a']));
+        $this->assertEquals(['class' => 'b'], $this->object->renameClasses(['a' => 'b', 'c' => 'd'], ['class' => 'a']));
+    }
+
+    public function testHasAnyClass()
+    {
+        $this->assertFalse($this->object->hasAnyClass('a', []));
+        $this->assertFalse($this->object->hasAnyClass('a', ['class' => 'x y z']));
+
+        $this->assertTrue($this->object->hasAnyClass('a', ['class' => 'a b c']));
+        $this->assertTrue($this->object->hasAnyClass('a w', ['class' => 'x y z a b c']));
+    }
+
+    public function testInjectClasses()
+    {
+        $this->assertEquals(['class' => 'a'], $this->object->injectClasses('a', []));
+        $this->assertEquals(['class' => 'a b c'], $this->object->injectClasses('a b c', []));
+        $this->assertEquals(['class' => 'x y z a'], $this->object->injectClasses('a', ['class' => 'x y z']));
+        $this->assertEquals(['class' => 'x y z a'], $this->object->injectClasses('a', ['class' => ['x', 'y', 'z']]));
+        $this->assertEquals(['class' => 'x y z a b c'], $this->object->injectClasses('a b c', ['class' => 'x y z']));
+    }
+
+    public function testOverlappingInjectClasses()
+    {
+        $this->assertEquals(['class' => 'a b c x y z'], $this->object->injectClasses('a b c', ['class' => 'a b c x y z']));
+        $this->assertEquals(['class' => 'a b c x y z'], $this->object->injectClasses('a', ['class' => 'a b c x y z']));
+        $this->assertEquals(['class' => 'a c x y z b'], $this->object->injectClasses('a b c', ['class' => 'a c x y z']));
+    }
+
+    public function testSkippingInjectClasses()
+    {
+        $this->assertEquals(['class' => 'x y z a c'], $this->object->injectClasses('a b c', ['class' => 'x y z', 'skip' => 'b']));
+        $this->assertEquals(['class' => 'x y z a b c'], $this->object->injectClasses('a b c', ['class' => 'x y z', 'skip' => 'm']));
+    }
+
+    public function testCheckClasses()
+    {
+        foreach (['a', 'a b c', ['a'], ['a', 'b', 'c']] as $class) {
+            $this->assertFalse($this->object->checkClasses($class, []));
+            $this->assertFalse($this->object->checkClasses($class, ['class' => 'x y z']));
+            $this->assertFalse($this->object->checkClasses($class, ['class' => ['x', 'y', 'z']]));
+        }
+
+        $this->assertTrue($this->object->checkClasses('a', ['class' => 'a']));
+        $this->assertTrue($this->object->checkClasses('a b c', ['class' => 'c b a']));
+        $this->assertTrue($this->object->checkClasses('a b c', ['class' => ['c', 'b', 'a']]));
+    }
+}

--- a/tests/TestCase/View/Helper/OptionsAwareTraitTest.php
+++ b/tests/TestCase/View/Helper/OptionsAwareTraitTest.php
@@ -37,10 +37,10 @@ class OptionsAwareTraitTest extends TestCase
 
     public function testApplyButtonStyles()
     {
-        $this->assertEquals(['class' => 'btn btn-default'], $this->object->applyButtonStyles([]));
+        $this->assertEquals(['class' => 'btn btn-default'], $this->object->applyButtonClasses([]));
         foreach (['default', 'success', 'warning', 'danger', 'info', 'primary'] as $style) {
-            $this->assertEquals(['class' => "btn-{$style} btn"], $this->object->applyButtonStyles(['class' => $style]));
-            $this->assertEquals(['class' => "btn-{$style} btn"], $this->object->applyButtonStyles(['class' => "btn-$style"]));
+            $this->assertEquals(['class' => "btn-{$style} btn"], $this->object->applyButtonClasses(['class' => $style]));
+            $this->assertEquals(['class' => "btn-{$style} btn"], $this->object->applyButtonClasses(['class' => "btn-$style"]));
         }
     }
 

--- a/tests/TestCase/View/Widget/ButtonWidgetTest.php
+++ b/tests/TestCase/View/Widget/ButtonWidgetTest.php
@@ -17,12 +17,12 @@ class ButtonWidgetTest extends TestCase
     /**
      * @var StringTemplate
      */
-    private $templates;
+    public $templates;
 
     /**
      * @var ContextInterface
      */
-    private $context;
+    public $context;
 
     /**
      * setUp method

--- a/tests/TestCase/View/Widget/ButtonWidgetTest.php
+++ b/tests/TestCase/View/Widget/ButtonWidgetTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace BootstrapUI\Test\TestCase\View\Widget;
+
+use BootstrapUI\View\Widget\ButtonWidget;
+use Cake\Network\Session;
+use Cake\TestSuite\TestCase;
+use Cake\View\Form\ContextInterface;
+use Cake\View\StringTemplate;
+
+/**
+ * ButtonWidgetTest class
+ *
+ */
+class ButtonWidgetTest extends TestCase
+{
+    /**
+     * @var StringTemplate
+     */
+    private $templates;
+
+    /**
+     * @var ContextInterface
+     */
+    private $context;
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $templates = [
+            'button' => '<button{{attrs}}>{{text}}</button>',
+        ];
+        $this->templates = new StringTemplate($templates);
+        $this->context = $this->getMock('Cake\View\Form\ContextInterface');
+    }
+
+    /**
+     * Test render in a simple case.
+     *
+     * @return void
+     */
+    public function testRenderSimple()
+    {
+        $button = new ButtonWidget($this->templates);
+        $result = $button->render(['name' => 'my_input'], $this->context);
+        $expected = [
+            'button' => ['type' => 'submit', 'name' => 'my_input', 'class' => 'btn btn-default'],
+            '/button'
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * Test render different button styles.
+     *
+     * @return void
+     */
+    public function testRenderDifferentStyles()
+    {
+        $styles = [
+            'default',
+            'success',
+            'warning',
+            'danger',
+            'info',
+            'primary'
+        ];
+
+        $button = new ButtonWidget($this->templates);
+
+        foreach ($styles as $style) {
+            $expected = [
+                'button' => ['type' => 'submit', 'name' => 'my_input', 'class' => "btn-{$style} btn"],
+                '/button'
+            ];
+
+            // support both "style" and "btn-style"
+            foreach ([$style, "btn-$style"] as $type) {
+                $result = $button->render(['name' => 'my_input', 'class' => $type], $this->context);
+                $this->assertHtml($expected, $result);
+            }
+        }
+    }
+
+    /**
+     * Test render with custom type
+     *
+     * @return void
+     */
+    public function testRenderType()
+    {
+        $button = new ButtonWidget($this->templates);
+        $data = [
+            'name' => 'my_input',
+            'type' => 'button',
+            'text' => 'Some button'
+        ];
+        $result = $button->render($data, $this->context);
+        $expected = [
+            'button' => ['type' => 'button', 'name' => 'my_input', 'class' => 'btn btn-default'],
+            'Some button',
+            '/button'
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * Test render with a text
+     *
+     * @return void
+     */
+    public function testRenderWithText()
+    {
+        $button = new ButtonWidget($this->templates);
+        $data = [
+            'text' => 'Some <value>'
+        ];
+        $result = $button->render($data, $this->context);
+        $expected = [
+            'button' => ['type' => 'submit', 'class' => 'btn btn-default'],
+            'Some <value>',
+            '/button'
+        ];
+        $this->assertHtml($expected, $result);
+
+        $data['escape'] = true;
+        $result = $button->render($data, $this->context);
+        $expected = [
+            'button' => ['type' => 'submit', 'class' => 'btn btn-default'],
+            'Some &lt;value&gt;',
+            '/button'
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * Test render with additional attributes.
+     *
+     * @return void
+     */
+    public function testRenderAttributes()
+    {
+        $button = new ButtonWidget($this->templates);
+        $data = [
+            'name' => 'my_input',
+            'text' => 'Go',
+            'class' => 'btn',
+            'required' => true
+        ];
+        $result = $button->render($data, $this->context);
+        $expected = [
+            'button' => [
+                'type' => 'submit',
+                'name' => 'my_input',
+                'class' => 'btn btn-default',
+                'required' => 'required'
+            ],
+            'Go',
+            '/button'
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * Ensure templateVars option is hooked up.
+     *
+     * @return void
+     */
+    public function testRenderTemplateVars()
+    {
+        $this->templates->add([
+            'button' => '<button {{attrs}} custom="{{custom}}">{{text}}</button>',
+        ]);
+
+        $button = new ButtonWidget($this->templates);
+        $data = [
+            'templateVars' => ['custom' => 'value'],
+            'text' => 'Go',
+        ];
+        $result = $button->render($data, $this->context);
+        $expected = [
+            'button' => [
+                'type' => 'submit',
+                'custom' => 'value',
+                'class' => 'btn btn-default'
+            ],
+            'Go',
+            '/button'
+        ];
+        $this->assertHtml($expected, $result);
+    }
+}


### PR DESCRIPTION
This PR improves buttons.

- closes #143 as button widget now assigns `btn-default` if it's missing.
- ButtonWidget now checks for both `primary` and `btn-primary` classname patterns in class attribute.
- Adds unit test coverage for ButtonWidget
- Fixes `btn-default` for `Form->submit()` which didn't use ButtonWidget.

I added a public static method to ButtonWidget which is called from FormHelper. So that there is only one function that handles class styles for buttons. I'm not sure if a helper should call a static on a widget. Seems dirty to me. Is this okay for now?