### PR TITLE
Allow the dashboard header to be set manually

### DIFF
--- a/src/Template/Layout/examples/dashboard.ctp
+++ b/src/Template/Layout/examples/dashboard.ctp
@@ -44,7 +44,9 @@ $this->start('tb_body_start');
                 <?= $this->fetch('tb_sidebar') ?>
             </div>
             <div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">
-                <h1 class="page-header"><?= $this->request->controller; ?></h1>
+                <h1 class="page-header">
+                    <?= $this->fetch('tb_header', $this->request->controller) ?>
+                </h1>
 <?php
 /**
  * Default `flash` block.


### PR DESCRIPTION
## Description

Allow the dashboard header to be set manually instead of using the Controller name

Previously, the controller name was used for the dashboard page header. However if the controller was more than one word long then the header would be the Controller name without any spaces
