### PR TITLE
Remove space in controller value for new action link

### DIFF
--- a/src/Template/Bake/Template/index.ctp
+++ b/src/Template/Bake/Template/index.ctp
@@ -15,7 +15,7 @@ foreach ($associations as $type => $data):
         if ($details['controller'] != $this->name && !in_array($details['controller'], $done)):
             %>
     <li><?= $this->Html->link(__('List <%= Inflector::humanize($details["controller"]) %>'), ['controller' => '<%= $details["controller"] %>', 'action' => 'index']); ?></li>
-    <li><?= $this->Html->link(__('New <%= Inflector::humanize(Inflector::singularize(Inflector::underscore($alias))) %>'), ['controller' => ' <%= $details["controller"] %>', 'action' => 'add']); ?></li>
+    <li><?= $this->Html->link(__('New <%= Inflector::humanize(Inflector::singularize(Inflector::underscore($alias))) %>'), ['controller' => '<%= $details["controller"] %>', 'action' => 'add']); ?></li>
 <%
             $done[] = $details['controller'];
         endif;


### PR DESCRIPTION
## Description
The generated links for "New Association" have a space preceding the controller name.  The links seem to work but I thought it should be cleaned up.

## Summarize
Removed the space preceding the controller name.

## Benefits
Saves OCD developers from having to remove spaces in baked templates.

## Related Issues
N/A

fixes #

The links generated for "New" actions have a space prefixing the controller name - which seems to work fine, but wanted to clean up.