### PR TITLE
Input group options for textarea

### DIFF
--- a/src/View/Widget/TextareaWidget.php
+++ b/src/View/Widget/TextareaWidget.php
@@ -31,8 +31,76 @@ class TextareaWidget extends \Cake\View\Widget\TextareaWidget
      */
     public function render(array $data, ContextInterface $context)
     {
-        $data = $this->injectClasses('form-control', $data);
+        $data += [
+            'type' => 'textarea',
+            'prepend' => null,
+            'append' => null,
+        ];
+        if ($data['type'] !== 'hidden') {
+            $data = $this->injectClasses('form-control', $data);
+        }
 
-        return parent::render($data, $context);
+        $prepend = $data['prepend'];
+        $append = $data['append'];
+        unset($data['append'], $data['prepend']);
+
+        $input = parent::render($data, $context);
+
+        if ($prepend) {
+            $prepend = $this->_addon($prepend, $data);
+        }
+        if ($append) {
+            $append = $this->_addon($append, $data);
+        }
+
+        if ($prepend || $append) {
+            $input = $this->_templates->format('inputGroupContainer', [
+                'append' => $append,
+                'prepend' => $prepend,
+                'content' => $input,
+                'templateVars' => $data['templateVars'],
+            ]);
+        }
+
+        return $input;
+    }
+
+    /**
+     * Get addon HTML.
+     *
+     * @param string|array $addon Addon content.
+     * @param array $data Widget data.
+     * @return string
+     */
+    protected function _addon($addon, $data)
+    {
+        if (is_string($addon)) {
+            $class = 'input-group-' . ($this->_isButton($addon) ? 'btn' : 'addon');
+            $addon = $this->_templates->format('inputGroupAddon', [
+                'class' => $class,
+                'content' => $addon,
+                'templateVars' => $data['templateVars'],
+            ]);
+        } else {
+            $class = 'input-group-btn';
+            $addon = $this->_templates->format('inputGroupAddon', [
+                'class' => $class,
+                'content' => implode('', $addon),
+                'templateVars' => $data['templateVars'],
+            ]);
+        }
+
+        return $addon;
+    }
+
+    /**
+     * Checks if an HTML markup is for a button.
+     *
+     * @param string $html Markup to check.
+     * @return bool TRUE if it's a button.
+     */
+    protected function _isButton($html)
+    {
+        return strpos($html, '<button') !== false || strpos($html, 'type="submit"') !== false;
     }
 }


### PR DESCRIPTION
In this current stable version, input group facilities exist only for input but not for textarea. Although it not documented on bootstrap, but bootstrap also support input group addon for textarea. Please check http://stackoverflow.com/a/24558352/1787600