### PR TITLE
Remove Bad Apostrophes

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ class AppView extends View
 
 ## BootstrapUI Layout
 
-BootstrapUI comes with it's own `layout.ctp` file and examples taken from the Bootstrap framework.
+BootstrapUI comes with its own `layout.ctp` file and examples taken from the Bootstrap framework.
 
-When no layout for the view is defined the `BootstrapUI\View\UIViewTrait` will load it's own `layout.ctp` file. You can
+When no layout for the view is defined the `BootstrapUI\View\UIViewTrait` will load its own `layout.ctp` file. You can
 override this behavior in two ways.
 
 - Assign a layout to the view with `$this->layout('layout')`.


### PR DESCRIPTION
A possessive belonging to an "it" doesn't need an apostrophe. Don't believe me? Ask [the Oatmeal](http://theoatmeal.com/comics/apostrophe) (look for the velociraptor)!