### PR TITLE
Added viewport meta to enable responsive layout

### DIFF
--- a/src/Template/Layout/default.ctp
+++ b/src/Template/Layout/default.ctp
@@ -65,7 +65,7 @@ $this->prepend('meta', $this->Html->meta('favicon.ico', '/favicon.ico', ['type' 
  */
 $html5Shim =
 <<<HTML
-    
+
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
@@ -89,6 +89,7 @@ $this->prepend('script', $this->Html->script(['jquery/jquery', 'bootstrap/bootst
     <head>
 
         <?= $this->Html->charset() ?>
+        <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 
         <title><?= $this->fetch('title') ?></title>
 


### PR DESCRIPTION
## Description
The viewport meta tag was missing from the default layout template.

## Summarize
Just added the following line on `src/Template/Layout/default.ctp`:
```html
<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
```
## Benefits
Enables Bootstrap responsive layout capabilities.

## Related Issues
There wasn't any.
