### PR TITLE
Update UIViewTrait to check if helpers were loaded

### DIFF
--- a/src/View/UIViewTrait.php
+++ b/src/View/UIViewTrait.php
@@ -29,9 +29,17 @@ trait UIViewTrait
             $this->layout = $options['layout'];
         }
 
-        $this->loadHelper('Html', ['className' => 'BootstrapUI.Html']);
-        $this->loadHelper('Form', ['className' => 'BootstrapUI.Form']);
-        $this->loadHelper('Flash', ['className' => 'BootstrapUI.Flash']);
-        $this->loadHelper('Paginator', ['className' => 'BootstrapUI.Paginator']);
+        if (!$this->helpers()->has('Html')) {
+            $this->loadHelper('Html', ['className' => 'BootstrapUI.Html']);
+        }
+        if (!$this->helpers()->has('Form')) {
+            $this->loadHelper('Form', ['className' => 'BootstrapUI.Form']);
+        }
+        if (!$this->helpers()->has('Flash')) {
+            $this->loadHelper('Flash', ['className' => 'BootstrapUI.Flash']);
+        }
+        if (!$this->helpers()->has('Paginator')) {
+            $this->loadHelper('Paginator', ['className' => 'BootstrapUI.Paginator']);
+        }
     }
 }


### PR DESCRIPTION
### Description
I would like to use custom Html helper concurrently with BootstrapUI, so I tried to load MyAppHtmlHelper from AppView.php

    $this->loadHelper('Html', [
        'className' => 'MyAppHtml',
    ]);


and ended with _Fatal error: [RuntimeException] The "Html" alias has already been loaded_

### Solution
I am not sure if it is bug or feature of CakePHP that it is not ignoring second load of same helper, so I ended up with this "patch" of UIViewTrait, to check if helper was previously loaded.

_Edit: according to documenation, it is feature_
https://github.com/cakephp/cakephp/blob/be86aa9fd1e485c11fe785e0183836cfec3030fb/src/Core/ObjectRegistry.php#L102
 
    if (!$this->helpers()->has('Html')) {
        $this->loadHelper('Html', ['className' => 'BootstrapUI.Html']);
    }

..etc for other helpers.

Is this good idea? 


