### PR TITLE
Dont use deprecated functionality.

### DIFF
--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -41,7 +41,9 @@ class PaginatorHelperTest extends TestCase
         Configure::write('Config.language', 'eng');
         $this->View = new View();
         $this->Paginator = new PaginatorHelper($this->View);
-        $this->Paginator->Js = $this->getMock('Cake\View\Helper\PaginatorHelper', [], [$this->View]);
+        $this->Paginator->Js = $this->getMockBuilder('Cake\View\Helper\PaginatorHelper')
+            ->setConstructorArgs([$this->View])
+            ->getMock();
         $this->Paginator->request = new Request();
         $this->Paginator->request->addParams([
             'paging' => [

--- a/tests/TestCase/View/Widget/ButtonWidgetTest.php
+++ b/tests/TestCase/View/Widget/ButtonWidgetTest.php
@@ -36,7 +36,7 @@ class ButtonWidgetTest extends TestCase
             'button' => '<button{{attrs}}>{{text}}</button>',
         ];
         $this->templates = new StringTemplate($templates);
-        $this->context = $this->getMock('Cake\View\Form\ContextInterface');
+        $this->context = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
     }
 
     /**


### PR DESCRIPTION
Resolves

```
There were 7 warnings:

1) BootstrapUI\Test\TestCase\View\Helper\PaginatorHelperTest::testNumbers
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestC
ase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

2) BootstrapUI\Test\TestCase\View\Widget\ButtonWidgetTest::testRenderSimple
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestC
ase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

3) BootstrapUI\Test\TestCase\View\Widget\ButtonWidgetTest::testRenderDifferentSt
yles
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestC
ase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

4) BootstrapUI\Test\TestCase\View\Widget\ButtonWidgetTest::testRenderType
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestC
ase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

5) BootstrapUI\Test\TestCase\View\Widget\ButtonWidgetTest::testRenderWithText
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestC
ase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

6) BootstrapUI\Test\TestCase\View\Widget\ButtonWidgetTest::testRenderAttributes
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestC
ase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

7) BootstrapUI\Test\TestCase\View\Widget\ButtonWidgetTest::testRenderTemplateVar
s
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestC
ase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead
```
