### PR TITLE
FormHelper _groupTemplate

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -379,7 +379,7 @@ class FormHelper extends Helper
         }
 
         return $this->templater()->format($groupTemplate, [
-            'input' => $options['input'],
+            'input' => isset($options['input']) ? $options['input'] : [],
             'label' => $options['label'],
             'error' => $options['error'],
             'templateVars' => isset($options['options']['templateVars']) ? $options['options']['templateVars'] : [],


### PR DESCRIPTION
Changes in CakePHP [https://github.com/cakephp/cakephp/pull/10100](url) created an instance where the input index of $options might not exist.  

## Description
Created a shorthand statement to reference the input index of the $options array if it is set, if not use an empty array.

## Summarize
Only one change, outlined above.

## Benefits
Fixed notice error that was present after updating to CakePHP 3.3.13

## Related Issues


fixes #179.
