### PR TITLE
set array index to empty array if it doesn't exist

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -379,7 +379,7 @@ class FormHelper extends Helper
         }
 
         return $this->templater()->format($groupTemplate, [
-            'input' => $options['input'],
+            'input' => isset($options['input']) ? $options['input'] : [],
             'label' => $options['label'],
             'error' => $options['error'],
             'templateVars' => isset($options['options']['templateVars']) ? $options['options']['templateVars'] : [],


### PR DESCRIPTION
## Description
This serves to prevent debug errors by passing an empty array if the `$options['input']` key does not exist.

## Summarize
This serves to prevent debug errors by passing an empty array if the `$options['input']` key does not exist.