### PR TITLE
fixing clearfix for FormHelper::submit in form-horizontal

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -63,7 +63,7 @@ class FormHelper extends Helper
             'label' => '<label class="control-label %s"{{attrs}}>{{text}}</label>',
             'formGroup' => '{{label}}<div class="%s">{{input}}{{error}}{{help}}</div>',
             'checkboxFormGroup' => '<div class="%s"><div class="checkbox">{{label}}</div>{{error}}{{help}}</div>',
-            'submitContainer' => '<div class="%s">{{content}}</div>',
+            'submitContainer' => '<div class="form-group"><div class="%s">{{content}}</div></div>',
             'inputContainer' => '<div class="form-group {{type}}{{required}}">{{content}}</div>',
             'inputContainerError' => '<div class="form-group {{type}}{{required}} has-error">{{content}}</div>',
             'checkboxContainer' => '<div class="form-group{{required}}">{{content}}</div>',

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -1173,6 +1173,24 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
     }
 
+    public function testHorizontalFormSubmit()
+    {
+        $this->Form->create($this->article, ['align' => 'horizontal']);
+
+        $result = $this->Form->submit('Submit');
+        $expected = [
+            'div' => ['class' => 'form-group'],
+            ['div' => ['class' => 'col-md-offset-2 col-md-6']],
+            'input' => [
+                'type' => 'submit',
+                'value' => 'Submit',
+                'class' => 'btn btn-default',
+            ]
+        ];
+
+        $this->assertHtml($expected, $result);
+    }
+
     public function testStyledButton()
     {
         $result = $this->Form->button('Submit', ['class' => 'success']);


### PR DESCRIPTION
## Description
when using `Form->submit()`, the resulting html failed to be wrapped in between `<div class="form-group"></div>`. This resulted in a missing clear fix when using form-horizontal, breaking the form.

## Summarize
This Pull Request adds the missing `form-group` wrapper and fixes the issue.

## Related Issues
This PR addresses the following issues.

fixes #161
