### PR TITLE
Feature/tooltips

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -43,7 +43,7 @@ class FormHelper extends Helper
         'dateWidget' => '<ul class="list-inline"><li class="year">{{year}}</li><li class="month">{{month}}</li><li class="day">{{day}}</li><li class="hour">{{hour}}</li><li class="minute">{{minute}}</li><li class="second">{{second}}</li><li class="meridian">{{meridian}}</li></ul>',
         'error' => '<div class="help-block">{{content}}</div>',
         'help' => '<div class="help-block">{{content}}</div>',
-        'tooltip' => '<span rel="tooltip" title="{{content}}" class="glyphicon glyphicon-info-sign"></span>',
+        'tooltip' => '<span data-toggle="tooltip" title="{{content}}" class="glyphicon glyphicon-info-sign"></span>',
         'inputContainer' => '<div class="form-group {{type}}{{required}}">{{content}}{{help}}</div>',
         'inputContainerError' => '<div class="form-group {{type}}{{required}} has-error">{{content}}{{error}}{{help}}</div>',
         'radioInlineFormGroup' => '{{label}}<div class="radio-inline-wrapper">{{input}}</div>',

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -43,10 +43,11 @@ class FormHelper extends Helper
         'dateWidget' => '<ul class="list-inline"><li class="year">{{year}}</li><li class="month">{{month}}</li><li class="day">{{day}}</li><li class="hour">{{hour}}</li><li class="minute">{{minute}}</li><li class="second">{{second}}</li><li class="meridian">{{meridian}}</li></ul>',
         'error' => '<div class="help-block">{{content}}</div>',
         'help' => '<div class="help-block">{{content}}</div>',
+        'tooltip' => '<span rel="tooltip" title="{{content}}" class="glyphicon glyphicon-info-sign"></span>',
         'inputContainer' => '<div class="form-group {{type}}{{required}}">{{content}}{{help}}</div>',
         'inputContainerError' => '<div class="form-group {{type}}{{required}} has-error">{{content}}{{error}}{{help}}</div>',
         'radioInlineFormGroup' => '{{label}}<div class="radio-inline-wrapper">{{input}}</div>',
-        'radioNestingLabel' => '<div class="radio">{{hidden}}<label{{attrs}}>{{input}}{{text}}</label></div>',
+        'radioNestingLabel' => '<div class="radio">{{hidden}}<label{{attrs}}>{{input}}{{text}}{{tooltip}}</label></div>',
         'staticControl' => '<p class="form-control-static">{{content}}</p>',
         'inputGroupAddon' => '<span class="{{class}}">{{content}}</span>',
         'inputGroupContainer' => '<div class="input-group">{{prepend}}{{content}}{{append}}</div>',
@@ -63,11 +64,11 @@ class FormHelper extends Helper
             'checkboxContainerError' => '<div class="checkbox has-error">{{content}}{{error}}{{help}}</div>',
         ],
         'inline' => [
-            'label' => '<label class="sr-only"{{attrs}}>{{text}}</label>',
+            'label' => '<label class="sr-only"{{attrs}}>{{text}}{{tooltip}}</label>',
             'inputContainer' => '{{content}}'
         ],
         'horizontal' => [
-            'label' => '<label class="control-label %s"{{attrs}}>{{text}}</label>',
+            'label' => '<label class="control-label %s"{{attrs}}>{{text}}{{tooltip}}</label>',
             'formGroup' => '{{label}}<div class="%s">{{input}}{{error}}{{help}}</div>',
             'checkboxFormGroup' => '<div class="%s"><div class="checkbox">{{label}}</div>{{error}}{{help}}</div>',
             'submitContainer' => '<div class="form-group"><div class="%s">{{content}}</div></div>',
@@ -223,6 +224,7 @@ class FormHelper extends Helper
             'required' => null,
             'options' => null,
             'help' => null,
+            'tooltip' => null,
             'templates' => [],
             'templateVars' => []
         ];
@@ -285,6 +287,15 @@ class FormHelper extends Helper
                 'help',
                 ['content' => $options['help']]
             );
+        }
+
+        if ($options['tooltip']) {
+            $tooltip = $this->templater()->format(
+                'tooltip',
+                ['content' => $options['tooltip']]
+            );
+            $options['label']['templateVars']['tooltip'] = ' ' . $tooltip;
+            unset($options['tooltip']);
         }
 
         $controlMethod = $this->_controlMethod;
@@ -396,7 +407,7 @@ class FormHelper extends Helper
             'label' => $options['label'],
             'error' => $options['error'],
             'templateVars' => isset($options['options']['templateVars']) ? $options['options']['templateVars'] : [],
-            'help' => $options['options']['help']
+            'help' => $options['options']['help'],
         ]);
     }
 
@@ -419,7 +430,7 @@ class FormHelper extends Helper
             'required' => $options['options']['required'] ? ' required' : '',
             'type' => $options['options']['type'],
             'templateVars' => isset($options['options']['templateVars']) ? $options['options']['templateVars'] : [],
-            'help' => $options['options']['help']
+            'help' => $options['options']['help'],
         ]);
     }
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -42,6 +42,7 @@ class FormHelper extends Helper
     protected $_templates = [
         'dateWidget' => '<ul class="list-inline"><li class="year">{{year}}</li><li class="month">{{month}}</li><li class="day">{{day}}</li><li class="hour">{{hour}}</li><li class="minute">{{minute}}</li><li class="second">{{second}}</li><li class="meridian">{{meridian}}</li></ul>',
         'error' => '<div class="help-block">{{content}}</div>',
+        'label' => '<label{{attrs}}>{{text}}{{tooltip}}</label>',
         'help' => '<div class="help-block">{{content}}</div>',
         'tooltip' => '<span data-toggle="tooltip" title="{{content}}" class="glyphicon glyphicon-info-sign"></span>',
         'inputContainer' => '<div class="form-group {{type}}{{required}}">{{content}}{{help}}</div>',

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -16,7 +16,7 @@ class FormHelper extends Helper
     /**
      * Set on `Form::create()` to tell if the type of alignment used (i.e. horizontal).
      *
-     * @var string
+     * @var string|null
      */
     protected $_align;
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -1501,6 +1501,32 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * @return void
+     */
+    public function testTooltip()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('title', ['tooltip' => 'Some important additional notes.']);
+        $expected = [
+            'div' => ['class' => 'form-group text required'],
+            'label' => ['class' => 'control-label', 'for' => 'title'],
+            'Title',
+            'span' => ['rel' => 'tooltip', 'title' => 'Some important additional notes.', 'class' => 'glyphicon glyphicon-info-sign'],
+            '/label',
+            'input' => [
+                'type' => 'text',
+                'name' => 'title',
+                'id' => 'title',
+                'class' => 'form-control',
+                'required' => 'required'
+            ],
+            '/div'
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
      * Test that "form-control" class is added when using methods for specific input.
      *
      * @return void

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -1508,11 +1508,12 @@ class FormHelperTest extends TestCase
         $this->Form->create($this->article);
 
         $result = $this->Form->control('title', ['tooltip' => 'Some important additional notes.']);
+        debug($result);
         $expected = [
             'div' => ['class' => 'form-group text required'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
             'Title',
-            'span' => ['rel' => 'tooltip', 'title' => 'Some important additional notes.', 'class' => 'glyphicon glyphicon-info-sign'],
+            'span' => ['data-toggle' => 'tooltip', 'title' => 'Some important additional notes.', 'class' => 'glyphicon glyphicon-info-sign'],
             '/label',
             'input' => [
                 'type' => 'text',
@@ -1523,6 +1524,36 @@ class FormHelperTest extends TestCase
             ],
             '/div'
         ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testTooltipHorizontal()
+    {
+        $this->Form->create($this->article, ['align' => 'horizontal']);
+
+        $result = $this->Form->control('title', ['tooltip' => 'Some important additional notes.']);
+        $expected = [
+            'div' => ['class' => 'form-group text required'],
+            'label' => ['class' => 'control-label col-md-2', 'for' => 'title'],
+            'Title ',
+            'span' => ['data-toggle' => 'tooltip', 'title' => 'Some important additional notes.', 'class' => 'glyphicon glyphicon-info-sign'],
+            '/span',
+            '/label',
+            ['div' => ['class' => 'col-md-6']],
+            'input' => [
+                'type' => 'text',
+                'name' => 'title',
+                'id' => 'title',
+                'class' => 'form-control',
+                'required' => 'required'
+            ],
+            '/div',
+            '/div'
+        ];
+        debug($result);
         $this->assertHtml($expected, $result);
     }
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -1508,12 +1508,12 @@ class FormHelperTest extends TestCase
         $this->Form->create($this->article);
 
         $result = $this->Form->control('title', ['tooltip' => 'Some important additional notes.']);
-        debug($result);
         $expected = [
             'div' => ['class' => 'form-group text required'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
             'Title',
             'span' => ['data-toggle' => 'tooltip', 'title' => 'Some important additional notes.', 'class' => 'glyphicon glyphicon-info-sign'],
+            '/span',
             '/label',
             'input' => [
                 'type' => 'text',
@@ -1553,7 +1553,6 @@ class FormHelperTest extends TestCase
             '/div',
             '/div'
         ];
-        debug($result);
         $this->assertHtml($expected, $result);
     }
 


### PR DESCRIPTION
This implements https://github.com/FriendsOfCake/bootstrap-ui/issues/204

Implements Bootstrap Tooltips for longer texts.

    echo $this->Form->control('foo', ['tooltip' => 'This is an important info.']);

Results in e.g.:
```html
...
<label class="control-label col-md-4 col-lg-3" for="foo">
Foo <span data-toggle="tooltip" title="This is an important info." class="glyphicon glyphicon-info-sign"></span>
</label>
...
```

I confirmed that it also works mobile by click then (with JS enabled) via `$('[data-toggle="tooltip"]').tooltip()`