### PR TITLE
Replace deprecated methods for CakePHP 3.6

### DIFF
--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -40,11 +40,11 @@ class FlashHelper extends Helper
      */
     public function render($key = 'flash', array $options = [])
     {
-        if (!$this->request->session()->check("Flash.$key")) {
+        if (!$this->request->getSession()->check("Flash.$key")) {
             return null;
         }
 
-        $stack = $this->request->session()->read("Flash.$key");
+        $stack = $this->request->getSession()->read("Flash.$key");
         if (!is_array($stack)) {
             throw new \UnexpectedValueException(sprintf(
                 'Value for flash setting key "%s" must be an array.',
@@ -60,7 +60,7 @@ class FlashHelper extends Helper
         foreach ($stack as $message) {
             $message = $options + $message;
             $message['params'] += $this->_config;
-            $this->request->session()->delete("Flash.$key");
+            $this->request->getSession()->delete("Flash.$key");
 
             $element = $message['element'];
             if (strpos($element, '.') === false &&

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -267,7 +267,7 @@ class FormHelper extends Helper
                 if (isset($options['multiple']) && $options['multiple'] === 'checkbox') {
                     $options['type'] = 'multicheckbox';
                 } else {
-                    if ($options['label'] !== false && strpos($this->templates('label'), 'class=') === false) {
+                    if ($options['label'] !== false && strpos($this->getTemplates('label'), 'class=') === false) {
                         $options['label'] = $this->injectClasses('control-label', (array)$options['label']);
                     }
                 }
@@ -278,7 +278,7 @@ class FormHelper extends Helper
 
             case 'textarea':
             default:
-                if ($options['label'] !== false && strpos($this->templates('label'), 'class=') === false) {
+                if ($options['label'] !== false && strpos($this->getTemplates('label'), 'class=') === false) {
                     $options['label'] = $this->injectClasses('control-label', (array)$options['label']);
                 }
         }
@@ -469,7 +469,7 @@ class FormHelper extends Helper
             $this->_grid = $options['align'];
             $options['align'] = 'horizontal';
         } elseif ($options['align'] === 'horizontal') {
-            $this->_grid = $this->config('grid');
+            $this->_grid = $this->getConfig('grid');
         }
 
         if (!in_array($options['align'], ['default', 'horizontal', 'inline'])) {
@@ -554,6 +554,6 @@ class FormHelper extends Helper
             }
         }
 
-        return $this->config('align');
+        return $this->getConfig('align');
     }
 }

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -74,14 +74,14 @@ class PaginatorHelper extends \Cake\View\Helper\PaginatorHelper
 
         if (isset($options['prev'])) {
             if ($options['prev'] === true) {
-                $options['prev'] = $this->config('labels.prev');
+                $options['prev'] = $this->getConfig('labels.prev');
             }
             $options['before'] .= $this->prev($options['prev'], ['escape' => false]);
         }
 
         if (isset($options['next'])) {
             if ($options['next'] === true) {
-                $options['next'] = $this->config('labels.next');
+                $options['next'] = $this->getConfig('labels.next');
             }
             $options['after'] = $this->next($options['next'], ['escape' => false]) . $options['after'];
         }

--- a/tests/TestCase/View/Helper/FlashHelperTest.php
+++ b/tests/TestCase/View/Helper/FlashHelperTest.php
@@ -3,8 +3,8 @@
 namespace BootstrapUI\Test\TestCase\View\Helper;
 
 use BootstrapUI\View\Helper\FlashHelper;
-use Cake\Network\Request;
 use Cake\Http\Session;
+use Cake\Network\Request;
 use Cake\TestSuite\TestCase;
 use Cake\View\View;
 

--- a/tests/TestCase/View/Helper/FlashHelperTest.php
+++ b/tests/TestCase/View/Helper/FlashHelperTest.php
@@ -4,7 +4,7 @@ namespace BootstrapUI\Test\TestCase\View\Helper;
 
 use BootstrapUI\View\Helper\FlashHelper;
 use Cake\Network\Request;
-use Cake\Network\Session;
+use Cake\Http\Session;
 use Cake\TestSuite\TestCase;
 use Cake\View\View;
 
@@ -122,7 +122,7 @@ class FlashHelperTest extends TestCase
      */
     public function testRenderForMultipleMessages()
     {
-        $this->View->request->session()->write([
+        $this->View->request->getSession()->write([
             'Flash' => [
                 'flash' => [
                     [

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -40,11 +40,11 @@ class FormHelperTest extends TestCase
 
         $this->Form = new FormHelper($this->View);
         $request = new Request('articles/add');
-        $request->here = '/articles/add';
-        $request['controller'] = 'articles';
-        $request['action'] = 'add';
-        $request->webroot = '';
-        $request->base = '';
+        $request = $request->withAttribute('here', '/articles/add');
+        $request = $request->withParam('controller', 'articles');
+        $request = $request->withParam('action', 'add');
+        $request = $request->withAttribute('webroot', '');
+        $request = $request->withAttribute('base', '');
         $this->Form->Url->request = $this->Form->request = $request;
 
         $this->article = [
@@ -62,7 +62,7 @@ class FormHelperTest extends TestCase
             ]
         ];
 
-        Security::salt('foo!');
+        Security::getSalt('foo!');
         Router::connect('/:controller', ['action' => 'index']);
         Router::connect('/:controller/:action/*');
     }
@@ -71,7 +71,7 @@ class FormHelperTest extends TestCase
     {
         parent::tearDown();
         unset($this->Form, $this->View);
-        TableRegistry::clear();
+        TableRegistry::getTableLocator()->clear();
     }
 
     public function testBasicTextInput()
@@ -79,7 +79,7 @@ class FormHelperTest extends TestCase
         unset($this->article['required']['title']);
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('title');
+        $result = $this->Form->control('title');
         $expected = [
             'div' => ['class' => 'form-group text'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
@@ -122,7 +122,7 @@ class FormHelperTest extends TestCase
     {
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('foreign_key', [
+        $result = $this->Form->control('foreign_key', [
             'type' => 'select',
             'class' => 'my-class'
         ]);
@@ -148,7 +148,7 @@ class FormHelperTest extends TestCase
         $this->article['defaults']['title'] = 'foo <u>bar</u>';
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('title', ['type' => 'staticControl']);
+        $result = $this->Form->control('title', ['type' => 'staticControl']);
         $expected = [
             'div' => ['class' => 'form-group staticControl'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
@@ -170,7 +170,7 @@ class FormHelperTest extends TestCase
 
         $this->Form->fields = [];
 
-        $result = $this->Form->input('title', ['type' => 'staticControl', 'hiddenField' => false, 'escape' => false]);
+        $result = $this->Form->control('title', ['type' => 'staticControl', 'hiddenField' => false, 'escape' => false]);
         $expected = [
             'div' => ['class' => 'form-group staticControl'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
@@ -193,7 +193,7 @@ class FormHelperTest extends TestCase
         unset($this->article['required']['title']);
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('title', ['label' => false]);
+        $result = $this->Form->control('title', ['label' => false]);
         $expected = [
             'div' => ['class' => 'form-group text'],
             'input' => [
@@ -212,7 +212,7 @@ class FormHelperTest extends TestCase
         unset($this->article['required']['title']);
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('title', ['label' => 'Custom Title']);
+        $result = $this->Form->control('title', ['label' => 'Custom Title']);
         $expected = [
             'div' => ['class' => 'form-group text'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
@@ -234,7 +234,7 @@ class FormHelperTest extends TestCase
         unset($this->article['required']['title']);
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('title', ['label' => ['foo' => 'bar', 'text' => 'Custom Title']]);
+        $result = $this->Form->control('title', ['label' => ['foo' => 'bar', 'text' => 'Custom Title']]);
         $expected = [
             'div' => ['class' => 'form-group text'],
             'label' => ['class' => 'control-label', 'for' => 'title', 'foo' => 'bar'],
@@ -256,7 +256,7 @@ class FormHelperTest extends TestCase
         $this->article['schema']['password'] = ['type' => 'string'];
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('password');
+        $result = $this->Form->control('password');
         $expected = [
             'div' => ['class' => 'form-group password'],
             'label' => ['class' => 'control-label', 'for' => 'password'],
@@ -277,7 +277,7 @@ class FormHelperTest extends TestCase
     {
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('title');
+        $result = $this->Form->control('title');
         $expected = [
             'div' => ['class' => 'form-group text required'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
@@ -303,7 +303,7 @@ class FormHelperTest extends TestCase
         ];
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('title');
+        $result = $this->Form->control('title');
         $expected = [
             'div' => ['class' => 'form-group text required has-error'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
@@ -326,7 +326,7 @@ class FormHelperTest extends TestCase
 
         $this->Form->create($this->article, ['align' => 'horizontal']);
 
-        $result = $this->Form->input('title');
+        $result = $this->Form->control('title');
         $expected = [
             'div' => ['class' => 'form-group text required has-error'],
             'label' => ['class' => 'control-label col-md-2', 'for' => 'title'],
@@ -349,7 +349,7 @@ class FormHelperTest extends TestCase
 
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('published');
+        $result = $this->Form->control('published');
         $expected = [
             'div' => ['class' => 'form-group has-error'],
             ['div' => ['class' => 'col-md-offset-2 col-md-6']],
@@ -382,7 +382,7 @@ class FormHelperTest extends TestCase
     {
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('title', ['prepend' => '@']);
+        $result = $this->Form->control('title', ['prepend' => '@']);
         $expected = [
             'div' => ['class' => 'form-group text required'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
@@ -404,7 +404,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('url', ['prepend' => 'http://']);
+        $result = $this->Form->control('url', ['prepend' => 'http://']);
         $expected = [
             'div' => ['class' => 'form-group text'],
             'label' => ['class' => 'control-label', 'for' => 'url'],
@@ -430,7 +430,7 @@ class FormHelperTest extends TestCase
     {
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('title', ['append' => '@']);
+        $result = $this->Form->control('title', ['append' => '@']);
         $expected = [
             'div' => ['class' => 'form-group text required'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
@@ -457,7 +457,7 @@ class FormHelperTest extends TestCase
     {
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('author_id', ['append' => '@']);
+        $result = $this->Form->control('author_id', ['append' => '@']);
         $expected = [
             'div' => ['class' => 'form-group select required'],
             'label' => ['class' => 'control-label', 'for' => 'author-id'],
@@ -484,7 +484,7 @@ class FormHelperTest extends TestCase
     {
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('body', [
+        $result = $this->Form->control('body', [
             'type' => 'textarea',
             'append' => $this->Form->button('GO')
         ]);
@@ -516,7 +516,7 @@ class FormHelperTest extends TestCase
     {
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('title', ['prepend' => $this->Form->button('GO')]);
+        $result = $this->Form->control('title', ['prepend' => $this->Form->button('GO')]);
         $expected = [
             'div' => ['class' => 'form-group text required'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
@@ -545,7 +545,7 @@ class FormHelperTest extends TestCase
     {
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('title', ['append' => $this->Form->button('GO')]);
+        $result = $this->Form->control('title', ['append' => $this->Form->button('GO')]);
         $expected = [
             'div' => ['class' => 'form-group text required'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
@@ -574,7 +574,7 @@ class FormHelperTest extends TestCase
     {
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('published', [
+        $result = $this->Form->control('published', [
             'type' => 'radio',
             'options' => ['Yes', 'No']
         ]);
@@ -619,7 +619,7 @@ class FormHelperTest extends TestCase
     {
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('published', [
+        $result = $this->Form->control('published', [
             'inline' => true,
             'type' => 'radio',
             'options' => ['Yes', 'No']
@@ -676,7 +676,7 @@ class FormHelperTest extends TestCase
             ]
         ]);
 
-        $result = $this->Form->input('published', [
+        $result = $this->Form->control('published', [
             'type' => 'radio',
             'options' => ['Yes', 'No']
         ]);
@@ -730,7 +730,7 @@ class FormHelperTest extends TestCase
             ]
         ]);
 
-        $result = $this->Form->input('published', [
+        $result = $this->Form->control('published', [
             'inline' => true,
             'type' => 'radio',
             'options' => ['Yes', 'No']
@@ -789,7 +789,7 @@ class FormHelperTest extends TestCase
 
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('published', [
+        $result = $this->Form->control('published', [
             'type' => 'radio',
             'options' => ['Yes', 'No'],
             'templates' => $templates
@@ -836,7 +836,7 @@ class FormHelperTest extends TestCase
     {
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('published');
+        $result = $this->Form->control('published');
         $expected = [
             'div' => ['class' => 'checkbox'],
             'input' => [
@@ -862,7 +862,7 @@ class FormHelperTest extends TestCase
     {
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('published', ['inline' => true]);
+        $result = $this->Form->control('published', ['inline' => true]);
         $expected = [
             'input' => [
                 'type' => 'hidden',
@@ -908,7 +908,7 @@ class FormHelperTest extends TestCase
         unset($this->article['required']['title']);
         $this->Form->create($this->article, ['templates' => 'custom_templates']);
 
-        $result = $this->Form->input('title');
+        $result = $this->Form->control('title');
         $expected = [
             'div' => ['class' => 'custom-container form-group'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
@@ -968,7 +968,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('title');
+        $result = $this->Form->control('title');
         $expected = [
             'div' => ['class' => 'form-group text required'],
             'label' => [
@@ -990,7 +990,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('published');
+        $result = $this->Form->control('published');
         $expected = [
             'div' => ['class' => 'form-group'],
             ['div' => ['class' => 'col-md-offset-2 col-md-6']],
@@ -1026,7 +1026,7 @@ class FormHelperTest extends TestCase
             ]
         ]);
 
-        $result = $this->Form->input('title');
+        $result = $this->Form->control('title');
         $expected = [
             'div' => ['class' => 'form-group text required'],
             'label' => [
@@ -1051,7 +1051,7 @@ class FormHelperTest extends TestCase
 
     public function testHorizontalFormCreateFromConfig()
     {
-        $this->Form->config([
+        $this->Form->setConfig([
             'align' => 'horizontal',
             'templateSet' => [
                 'horizontal' => [
@@ -1078,7 +1078,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('title');
+        $result = $this->Form->control('title');
         $expected = [
             'div' => ['class' => 'form-group text required'],
             'label' => [
@@ -1100,7 +1100,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('published');
+        $result = $this->Form->control('published');
         $expected = [
             'div' => ['class' => 'form-group'],
             ['div' => ['class' => 'col-md-offset-2 col-md-6']],
@@ -1264,7 +1264,7 @@ class FormHelperTest extends TestCase
     {
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('users', [
+        $result = $this->Form->control('users', [
             'multiple' => 'checkbox',
             'options' => [
                 1 => 'User 1',
@@ -1316,7 +1316,7 @@ class FormHelperTest extends TestCase
     {
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('title', ['help' => 'help text']);
+        $result = $this->Form->control('title', ['help' => 'help text']);
         $expected = [
             'div' => ['class' => 'form-group text required'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
@@ -1336,7 +1336,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('published', ['help' => 'help text']);
+        $result = $this->Form->control('published', ['help' => 'help text']);
         $expected = [
             'div' => ['class' => 'checkbox'],
             'input' => [
@@ -1365,7 +1365,7 @@ class FormHelperTest extends TestCase
         ];
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('title', ['help' => 'help text']);
+        $result = $this->Form->control('title', ['help' => 'help text']);
         $expected = [
             'div' => ['class' => 'form-group text required has-error'],
             'label' => ['class' => 'control-label', 'for' => 'title'],
@@ -1388,7 +1388,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('title', [
+        $result = $this->Form->control('title', [
             'help' => 'help text',
             'templates' => ['help' => '<div class="custom-help-block">{{content}}</div>']
         ]);
@@ -1419,7 +1419,7 @@ class FormHelperTest extends TestCase
     {
         $this->Form->create($this->article, ['align' => 'horizontal']);
 
-        $result = $this->Form->input('title', ['help' => 'help text']);
+        $result = $this->Form->control('title', ['help' => 'help text']);
         $expected = [
             'div' => ['class' => 'form-group text required'],
             'label' => ['class' => 'control-label col-md-2', 'for' => 'title'],
@@ -1441,7 +1441,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('published', ['help' => 'help text']);
+        $result = $this->Form->control('published', ['help' => 'help text']);
         $expected = [
             'div' => ['class' => 'form-group'],
             ['div' => ['class' => 'col-md-offset-2 col-md-6']],
@@ -1474,7 +1474,7 @@ class FormHelperTest extends TestCase
         ];
         $this->Form->create($this->article, ['align' => 'horizontal']);
 
-        $result = $this->Form->input('title', ['help' => 'help text']);
+        $result = $this->Form->control('title', ['help' => 'help text']);
         $expected = [
             'div' => ['class' => 'form-group text required has-error'],
             'label' => ['class' => 'control-label col-md-2', 'for' => 'title'],

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -4,6 +4,7 @@ namespace BootstrapUI\Test\TestCase\View\Helper;
 
 use BootstrapUI\View\Helper\HtmlHelper;
 use Cake\TestSuite\TestCase;
+use BootstrapUI\View\Helper\BreadcrumbsHelper;
 use Cake\View\View;
 
 class HtmlHelperTest extends TestCase
@@ -18,12 +19,18 @@ class HtmlHelperTest extends TestCase
      */
     public $Html;
 
+    /**
+     * @var BreadcrumbsHelper
+     */
+    public $Breadcrumbs;
+
     public function setUp()
     {
         parent::setUp();
 
         $this->View = new View();
         $this->Html = new HtmlHelper($this->View);
+        $this->Breadcrumbs = new BreadcrumbsHelper($this->View);
     }
 
     public function tearDown()
@@ -96,25 +103,13 @@ class HtmlHelperTest extends TestCase
 
     public function testCrumbList()
     {
-        $result = $this->Html
-            ->addCrumb('jadb')
-            ->addCrumb('admad')
-            ->addCrumb('joe')
-            ->getCrumbList();
+        $result = $this->Breadcrumbs
+            ->add('jadb')
+            ->add('admad')
+            ->add('joe')
+            ->render();
 
-        $expected = [
-            'ul' => ['class' => 'breadcrumb'],
-            ['li' => ['class' => 'first']],
-            'jadb',
-            '/li',
-            '<li',
-            'admad',
-            '/li',
-            ['li' => ['class' => 'last']],
-            'joe',
-            '/li',
-            '/ul'
-        ];
-        $this->assertHtml($expected, $result);
+        $expected = '<ol class="breadcrumb"><li><span>jadb</span></li><li><span>admad</span></li><li><span>joe</span></li></ol>';
+        $this->assertEquals($expected, $result);
     }
 }

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -2,9 +2,9 @@
 
 namespace BootstrapUI\Test\TestCase\View\Helper;
 
+use BootstrapUI\View\Helper\BreadcrumbsHelper;
 use BootstrapUI\View\Helper\HtmlHelper;
 use Cake\TestSuite\TestCase;
-use BootstrapUI\View\Helper\BreadcrumbsHelper;
 use Cake\View\View;
 
 class HtmlHelperTest extends TestCase

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -45,7 +45,7 @@ class PaginatorHelperTest extends TestCase
             ->setConstructorArgs([$this->View])
             ->getMock();
         $this->Paginator->request = new Request();
-        $this->Paginator->request->addParams([
+        $this->Paginator->request = $this->Paginator->request->withAttribute('params', [
             'paging' => [
                 'Article' => [
                     'page' => 1,
@@ -66,7 +66,7 @@ class PaginatorHelperTest extends TestCase
         Router::connect('/:controller/:action/*');
         Router::connect('/:plugin/:controller/:action/*');
 
-        $this->locale = I18n::locale();
+        $this->locale = I18n::getLocale();
     }
 
     /**
@@ -79,7 +79,7 @@ class PaginatorHelperTest extends TestCase
         parent::tearDown();
         unset($this->View, $this->Paginator);
 
-        I18n::locale($this->locale);
+        I18n::setLocale($this->locale);
     }
 
     /**
@@ -89,7 +89,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testNumbers()
     {
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 8,
                 'current' => 3,
@@ -98,7 +98,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 2,
                 'pageCount' => 15,
             ]
-        ];
+        ]);
         $result = $this->Paginator->numbers();
         $expected = [
             'ul' => ['class' => 'pagination'],
@@ -115,7 +115,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 8,
                 'current' => 3,
@@ -124,7 +124,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 2,
                 'pageCount' => 15,
             ]
-        ];
+        ]);
         $result = $this->Paginator->numbers(['prev' => true, 'next' => true]);
         $expected = [
             'ul' => ['class' => 'pagination'],
@@ -143,7 +143,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 1,
                 'current' => 1,
@@ -152,7 +152,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 2,
                 'pageCount' => 2,
             ]
-        ];
+        ]);
         $result = $this->Paginator->numbers(['size' => 'lg']);
         $expected = [
             'ul' => ['class' => 'pagination pagination-lg'],

--- a/tests/TestCase/View/Widget/ButtonWidgetTest.php
+++ b/tests/TestCase/View/Widget/ButtonWidgetTest.php
@@ -3,7 +3,7 @@
 namespace BootstrapUI\Test\TestCase\View\Widget;
 
 use BootstrapUI\View\Widget\ButtonWidget;
-use Cake\Network\Session;
+use Cake\Http\Session;
 use Cake\TestSuite\TestCase;
 use Cake\View\Form\ContextInterface;
 use Cake\View\StringTemplate;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -65,7 +65,7 @@ Configure::write('App', [
     ]
 ]);
 
-Cache::config([
+Cache::setConfig([
     '_cake_core_' => [
         'engine' => 'File',
         'prefix' => 'cake_core_',


### PR DESCRIPTION
## Description
This pull request's replace deprecated methods/property calls with new ones.

## Summarize
- ``session()`` has been replaced with ``getSession()``
- ``templates()`` has been replaced with ``getTemplates()``
- ``config()`` has been replaced with ``getConfig()``/``setConfig()``
- ``Form->input()`` has been replaced with ``Form->control()``
- ``Security::salt()`` has been replaced with ``Security::getSalt()``
- ``TableRegistry::clear()`` has been replaced with ``TableRegistry::getTableLocator()->clear()``
- ``I18n::locale()`` has been replaced with ``I18n::getLocale()``
- Requests in test class has been changed to make use of new ``with*()`` methods
- Breadcrumb test has been replaced to use new ``BreadcrumbsHelper`` instead of ``HtmlHelper``