### PR TITLE
Added Missing Bower Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ A quick way of getting the Bootstrap assets installed is using [bower]. Assuming
 
 ```
 bower install bootstrap
+bower install jquery
 mkdir -p webroot/css/bootstrap webroot/js/bootstrap webroot/js/jquery webroot/css/fonts
 cp bower_components/bootstrap/dist/css/* webroot/css/bootstrap/.
 cp bower_components/bootstrap/dist/js/* webroot/js/bootstrap/.


### PR DESCRIPTION
bower install jquery
Above command was missing

## Description
Added missing jquery installation command

## Summarize
Write a list of the changes that were made.
- bower install jquery

## Benefits
This is helpful for new comer like me during installation
