### PR TITLE
Fixing detectFormAligment method

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -549,7 +549,7 @@ class FormHelper extends Helper
     protected function _detectFormAlignment($options)
     {
         foreach (['horizontal', 'inline'] as $align) {
-            if ($this->checkClasses('form-' . $align, (array)$options['class'])) {
+            if ($this->checkClasses('form-' . $align, $options)) {
                 return $align;
             }
         }

--- a/tests/TestCase/View/Helper/OptionsAwareTraitTest.php
+++ b/tests/TestCase/View/Helper/OptionsAwareTraitTest.php
@@ -93,5 +93,7 @@ class OptionsAwareTraitTest extends TestCase
         $this->assertTrue($this->object->checkClasses('a', ['class' => 'a']));
         $this->assertTrue($this->object->checkClasses('a b c', ['class' => 'c b a']));
         $this->assertTrue($this->object->checkClasses('a b c', ['class' => ['c', 'b', 'a']]));
+
+        $this->assertFalse($this->object->checkClasses('a', ['a']));
     }
 }


### PR DESCRIPTION
## Description
There was a small bug in the detectFormAligment method. 
checkClasses() uses the entire $options array and not just only the 'class' part

## Summarize
- Change the parameter on checkClasses call
