### PR TITLE
Fix bootstrap shell install test failure.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "cakephp/cakephp": "^3.5"
+        "cakephp/cakephp": "^3.5.12"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7.14|^6.0"

--- a/src/Shell/BootstrapShell.php
+++ b/src/Shell/BootstrapShell.php
@@ -27,7 +27,8 @@ class BootstrapShell extends Shell
     {
         $this->TwbsAssets->installAssets();
         $this->TwbsAssets->copyAssets();
-        $this->Assets->symlink();
+        $this->Assets->remove('BootstrapUI');
+        $this->Assets->symlink('BootstrapUI');
     }
 
     /**

--- a/src/Shell/Task/TwbsAssetsTask.php
+++ b/src/Shell/Task/TwbsAssetsTask.php
@@ -24,10 +24,10 @@ class TwbsAssetsTask extends Shell
     public function __construct()
     {
         parent::__construct();
-        $this->_assetDir = new Folder(Plugin::path('BootstrapUI') . 'webroot');
-        $this->_nodeDir = new Folder(Plugin::path('BootstrapUI') . 'node_modules');
-        $this->_cssDir = new Folder($this->_assetDir->path . DS . 'css');
-        $this->_jsDir = new Folder($this->_assetDir->path . DS . 'js');
+        $this->_assetDir = new Folder(Plugin::path('BootstrapUI') . 'webroot', true);
+        $this->_nodeDir = new Folder(Plugin::path('BootstrapUI') . 'node_modules', true);
+        $this->_cssDir = new Folder($this->_assetDir->path . DS . 'css', true);
+        $this->_jsDir = new Folder($this->_assetDir->path . DS . 'js', true);
     }
 
     /**

--- a/tests/TestCase/Shell/BootstrapShellTest.php
+++ b/tests/TestCase/Shell/BootstrapShellTest.php
@@ -80,7 +80,7 @@ class BootstrapShellTest extends TestCase
         $this->assertDirectoryExists($jsPath);
         $this->assertFileExists($jsPath . 'bootstrap.min.js');
         $this->assertFileExists($jsPath . 'jquery.min.js');
-        $this->assertFileExists($jsPath. 'popper.min.js');
+        $this->assertFileExists($jsPath . 'popper.min.js');
 
         $appWebrootPath = WWW_ROOT . 'bootstrap_u_i' . DS;
         $appCssPath = $webrootPath . 'css' . DS;

--- a/tests/TestCase/Shell/BootstrapShellTest.php
+++ b/tests/TestCase/Shell/BootstrapShellTest.php
@@ -31,15 +31,68 @@ class BootstrapShellTest extends TestCase
         unset($this->Shell);
     }
 
-    public function testInstall()
+    public function testInstallInDebugMode()
     {
         $this->Shell->install();
+
+        $pluginPath = Plugin::path('BootstrapUI');
+        $nodePath = $pluginPath . 'node_modules';
+        $webrootPath = $pluginPath . 'webroot' . DS;
+        $cssPath = $webrootPath . 'css' . DS;
+        $jsPath = $webrootPath . 'js' . DS;
+
+        $this->assertDirectoryExists($nodePath);
+        $this->assertDirectoryExists($webrootPath);
+        $this->assertDirectoryExists($cssPath);
+        $this->assertDirectoryExists($jsPath);
+
+        $appWebrootPath = WWW_ROOT . 'bootstrap_u_i' . DS;
+        $appCssPath = $webrootPath . 'css' . DS;
+        $appJsPath = $webrootPath . 'js' . DS;
+
+        $this->assertDirectoryExists($appWebrootPath);
+        $this->assertDirectoryExists($appCssPath);
+        $this->assertDirectoryExists($appJsPath);
+
+        $sourceFiles = (new Folder($webrootPath))->findRecursive();
+        $targetFiles = (new Folder($appWebrootPath))->findRecursive();
+        $this->assertEquals(count($sourceFiles), count($targetFiles));
+    }
+
+    public function testInstallInProductionMode()
+    {
         Configure::write('debug', false);
         $this->Shell->install();
+        Configure::write('debug', true);
 
-        $this->_assetDir = new Folder(Plugin::path('BootstrapUI') . 'webroot');
-        $this->assertDirectoryExists($this->_assetDir->path . DS . 'css');
-        $this->assertDirectoryExists($this->_assetDir->path . DS . 'js');
+        $pluginPath = Plugin::path('BootstrapUI');
+        $nodePath = $pluginPath . 'node_modules';
+        $webrootPath = $pluginPath . 'webroot' . DS;
+        $cssPath = $webrootPath . 'css' . DS;
+        $jsPath = $webrootPath . 'js' . DS;
+
+        $this->assertDirectoryExists($nodePath);
+        $this->assertDirectoryExists($webrootPath);
+
+        $this->assertDirectoryExists($cssPath);
+        $this->assertFileExists($cssPath . 'bootstrap.min.css');
+
+        $this->assertDirectoryExists($jsPath);
+        $this->assertFileExists($jsPath . 'bootstrap.min.js');
+        $this->assertFileExists($jsPath . 'jquery.min.js');
+        $this->assertFileExists($jsPath. 'popper.min.js');
+
+        $appWebrootPath = WWW_ROOT . 'bootstrap_u_i' . DS;
+        $appCssPath = $webrootPath . 'css' . DS;
+        $appJsPath = $webrootPath . 'js' . DS;
+
+        $this->assertDirectoryExists($appWebrootPath);
+        $this->assertDirectoryExists($appCssPath);
+        $this->assertDirectoryExists($appJsPath);
+
+        $sourceFiles = (new Folder($webrootPath))->findRecursive();
+        $targetFiles = (new Folder($appWebrootPath))->findRecursive();
+        $this->assertEquals(count($sourceFiles), count($targetFiles));
     }
 
     public function testCopyLayouts()


### PR DESCRIPTION
By default the `js` folder doesn't exist in the plugins webroot folder,
and the task doesn't create it, hence `$this->_jsDir->path` will be
`null`, causing the assets to be copied in the wrong directory.

refs #207

I've set all required folders to be auto-created, just in case existing folders might be removed in the future.