### PR TITLE
Develop fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,9 +65,9 @@
             }
         },
         "bootstrap": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.0.0.tgz",
-            "integrity": "sha512-gulJE5dGFo6Q61V/whS6VM4WIyrlydXfCgkE+Gxe5hjrJ8rXLLZlALq7zq2RPhOc45PSwQpJkrTnc2KgD6cvmA=="
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.1.1.tgz",
+            "integrity": "sha512-SpiDSOcbg4J/PjVSt4ny5eY6j74VbVSjROY4Fb/WIUXBV9cnb5luyR4KnPvNoXuGnBK1T+nJIWqRsvU3yP8Mcg=="
         },
         "brace-expansion": {
             "version": "1.1.8",
@@ -2532,9 +2532,9 @@
             "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
         },
         "popper.js": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.13.0.tgz",
-            "integrity": "sha1-4ef/ZcxD98+c8W8VEKdegfhPRWU="
+            "version": "1.14.3",
+            "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.3.tgz",
+            "integrity": "sha1-FDj5jQRqz3tNeM1QK/QYrGTU8JU="
         },
         "process-nextick-args": {
             "version": "1.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,6 @@
 {
-    "name": "bootstrap-ui",
-    "version": "1.2.1",
-    "lockfileVersion": 1,
     "requires": true,
+    "lockfileVersion": 1,
     "dependencies": {
         "ansi-regex": {
             "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
     "description": "Twitter Bootstrap 4 support for CakePHP 3",
     "main": "index.js",
     "dependencies": {
-        "bootstrap": "^4.0.0",
+        "bootstrap": "^4.1.0",
         "jquery": "^3.3.0",
-        "popper.js": "^1.13.0"
+        "popper.js": "^1.14.0"
     },
     "devDependencies": {},
     "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,29 +1,7 @@
 {
-    "name": "bootstrap-ui",
-    "version": "1.2.1",
-    "description": "Twitter Bootstrap 4 support for CakePHP 3",
-    "main": "index.js",
     "dependencies": {
         "bootstrap": "^4.1.0",
         "jquery": "^3.3.0",
         "popper.js": "^1.14.0"
-    },
-    "devDependencies": {},
-    "keywords": [
-        "cakephp",
-        "twitter",
-        "bootstrap"
-    ],
-    "author": "Jad Bitar http://jadb.io",
-    "contributors": [
-        {
-            "name": "Others",
-            "url": "https://github.com/friendsofcake/bootstrap-ui/graphs/contributors"
-        }
-    ],
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/FriendsOfCake/bootstrap-ui.git"
     }
 }

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -522,7 +522,7 @@ class FormHelper extends Helper
     {
         $class = 'col-%s-';
         if ($offset) {
-            $class .= 'offset-';
+            $class = 'offset-%s-';
         }
 
         if (isset($this->_grid[$position])) {

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -79,8 +79,8 @@ class FormHelper extends Helper
             'inputContainerError' => '<div class="form-group {{type}}{{required}} is-invalid">{{content}}</div>',
             'checkboxContainer' => '<div class="form-group {{type}}{{required}}">{{content}}</div>',
             'checkboxContainerError' => '<div class="form-group {{type}}{{required}} is-invalid">{{content}}</div>',
-            'radioContainer' => '<div class="form-group{{required}}">{{content}}</div>',
-            'radioContainerError' => '<div class="form-group{{required}} is-invalid">{{content}}</div>',
+            'radioContainer' => '<div class="form-group {{type}}{{required}}">{{content}}</div>',
+            'radioContainerError' => '<div class="form-group {{type}}{{required}} is-invalid">{{content}}</div>',
         ]
     ];
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -63,8 +63,8 @@ class FormHelper extends Helper
      */
     protected $_templateSet = [
         'default' => [
-            'checkboxContainer' => '<div class="form-check"{{required}}>{{content}}{{help}}</div>',
-            'checkboxContainerError' => '<div class="form-check">{{content}}{{error}}{{help}}</div>',
+            'checkboxContainer' => '<div class="form-group {{type}}{{required}}">{{content}}{{help}}</div>',
+            'checkboxContainerError' => '<div class="form-group {{type}}{{required}} is-invalid">{{content}}{{error}}{{help}}</div>',
         ],
         'inline' => [
             'label' => '<label class="sr-only"{{attrs}}>{{text}}{{tooltip}}</label>',
@@ -77,8 +77,8 @@ class FormHelper extends Helper
             'submitContainer' => '<div class="form-group"><div class="%s">{{content}}</div></div>',
             'inputContainer' => '<div class="form-group {{type}}{{required}}">{{content}}</div>',
             'inputContainerError' => '<div class="form-group {{type}}{{required}} is-invalid">{{content}}</div>',
-            'checkboxContainer' => '<div class="form-group{{required}}">{{content}}</div>',
-            'checkboxContainerError' => '<div class="form-group{{required}} is-invalid">{{content}}</div>',
+            'checkboxContainer' => '<div class="form-group {{type}}{{required}}">{{content}}</div>',
+            'checkboxContainerError' => '<div class="form-group {{type}}{{required}} is-invalid">{{content}}</div>',
             'radioContainer' => '<div class="form-group{{required}}">{{content}}</div>',
             'radioContainerError' => '<div class="form-group{{required}} is-invalid">{{content}}</div>',
         ]

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -110,8 +110,8 @@ class FormHelper extends Helper
             'errorClass' => 'is-invalid',
             'grid' => [
                 'left' => 2,
-                'middle' => 6,
-                'right' => 4
+                'middle' => 10,
+                'right' => 0,
             ],
             'templates' => $this->_templates + $this->_defaultConfig['templates'],
         ] + $this->_defaultConfig;

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -75,12 +75,12 @@ class FormHelper extends Helper
             'formGroup' => '{{label}}<div class="%s">{{input}}{{error}}{{help}}</div>',
             'checkboxFormGroup' => '<div class="%s"><div class="checkbox">{{label}}</div>{{error}}{{help}}</div>',
             'submitContainer' => '<div class="form-group"><div class="%s">{{content}}</div></div>',
-            'inputContainer' => '<div class="form-group {{type}}{{required}}">{{content}}</div>',
-            'inputContainerError' => '<div class="form-group {{type}}{{required}} is-invalid">{{content}}</div>',
-            'checkboxContainer' => '<div class="form-group {{type}}{{required}}">{{content}}</div>',
-            'checkboxContainerError' => '<div class="form-group {{type}}{{required}} is-invalid">{{content}}</div>',
-            'radioContainer' => '<div class="form-group {{type}}{{required}}">{{content}}</div>',
-            'radioContainerError' => '<div class="form-group {{type}}{{required}} is-invalid">{{content}}</div>',
+            'inputContainer' => '<div class="form-group row {{type}}{{required}}">{{content}}</div>',
+            'inputContainerError' => '<div class="form-group row {{type}}{{required}} is-invalid">{{content}}</div>',
+            'checkboxContainer' => '<div class="form-group row {{type}}{{required}}">{{content}}</div>',
+            'checkboxContainerError' => '<div class="form-group row {{type}}{{required}} is-invalid">{{content}}</div>',
+            'radioContainer' => '<div class="form-group row {{type}}{{required}}">{{content}}</div>',
+            'radioContainerError' => '<div class="form-group row {{type}}{{required}} is-invalid">{{content}}</div>',
         ]
     ];
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -268,21 +268,8 @@ class FormHelper extends Helper
             case 'select':
                 if (isset($options['multiple']) && $options['multiple'] === 'checkbox') {
                     $options['type'] = 'multicheckbox';
-                } else {
-                    if ($options['label'] !== false && strpos($this->getTemplates('label'), 'class=') === false) {
-                        $options['label'] = $this->injectClasses('col-form-label', (array)$options['label']);
-                    }
                 }
                 break;
-
-            case 'multiselect':
-                break;
-
-            case 'textarea':
-            default:
-                if ($options['label'] !== false && strpos($this->getTemplates('label'), 'class=') === false) {
-                    $options['label'] = $this->injectClasses('col-form-label', (array)$options['label']);
-                }
         }
 
         if ($options['help']) {

--- a/tests/TestCase/Shell/BootstrapShellTest.php
+++ b/tests/TestCase/Shell/BootstrapShellTest.php
@@ -57,6 +57,8 @@ class BootstrapShellTest extends TestCase
         $sourceFiles = (new Folder($webrootPath))->findRecursive();
         $targetFiles = (new Folder($appWebrootPath))->findRecursive();
         $this->assertEquals(count($sourceFiles), count($targetFiles));
+
+        (new Folder(WWW_ROOT))->delete();
     }
 
     public function testInstallInProductionMode()
@@ -93,20 +95,30 @@ class BootstrapShellTest extends TestCase
         $sourceFiles = (new Folder($webrootPath))->findRecursive();
         $targetFiles = (new Folder($appWebrootPath))->findRecursive();
         $this->assertEquals(count($sourceFiles), count($targetFiles));
+
+        (new Folder(WWW_ROOT))->delete();
     }
 
     public function testCopyLayouts()
     {
         $this->Shell->copyLayouts();
         $this->assertDirectoryExists(APP . 'Template' . DS . 'Layout' . DS . 'TwitterBootstrap');
+
+        (new Folder(APP . 'Template' . DS . 'Layout'))->delete();
     }
 
     public function testModifyView()
     {
         $view = new File(APP . 'View' . DS . 'AppView.php');
+        $original = $view->read();
+
         $this->Shell->modifyView();
         $this->assertContains('use BootstrapUI\\View\\UIView', (string)$view->read());
         $this->assertContains('class AppView extends UIView', (string)$view->read());
         $this->assertContains('parent::initialize();', (string)$view->read());
+
+        if ($view->writable()) {
+            $view->write($original);
+        }
     }
 }

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -796,7 +796,7 @@ class FormHelperTest extends TestCase
             'options' => ['Yes', 'No']
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group']],
+            ['div' => ['class' => 'form-group radio']],
             ['label' => ['class' => 'col-form-label col-sm-5']],
             'Published',
             '/label',
@@ -856,7 +856,7 @@ class FormHelperTest extends TestCase
             'options' => ['Yes', 'No']
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group']],
+            ['div' => ['class' => 'form-group radio']],
             ['label' => ['class' => 'col-form-label col-sm-5']],
             'Published',
             '/label',

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -364,6 +364,17 @@ class FormHelperTest extends TestCase
 
         $this->assertHtml($expected, $result);
 
+        $result = $this->Form->control('published');
+        $expected = [
+            ['div' => ['class' => 'form-group checkbox is-invalid']],
+            ['input' => ['type' => 'hidden', 'name' => 'published', 'class' => 'is-invalid', 'value' => '0']],
+            ['label' => ['for' => 'published']],
+            ['input' => ['type' => 'checkbox', 'name' => 'published', 'value' => '1', 'id' => 'published', 'class' => 'is-invalid']], 'Published', '/label',
+            ['div' => ['class' => 'invalid-feedback']], 'error message', '/div',
+            '/div'
+        ];
+        $this->assertHtml($expected, $result);
+
         $this->Form->create($this->article, ['align' => 'horizontal']);
 
         $result = $this->Form->control('title');
@@ -391,7 +402,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('published');
         $expected = [
-            ['div' => ['class' => 'form-group is-invalid']],
+            ['div' => ['class' => 'form-group checkbox is-invalid']],
             ['div' => ['class' => 'col-md-offset-2 col-md-6']],
             ['div' => ['class' => 'checkbox']],
             ['input' => ['type' => 'hidden', 'name' => 'published', 'class' => 'is-invalid', 'value' => '0']],
@@ -953,7 +964,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('published');
         $expected = [
-            'div' => ['class' => 'form-check'],
+            'div' => ['class' => 'form-group checkbox'],
             'input' => [
                 'type' => 'hidden',
                 'name' => 'published',
@@ -1145,7 +1156,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('published');
         $expected = [
-            'div' => ['class' => 'form-group'],
+            'div' => ['class' => 'form-group checkbox'],
             ['div' => ['class' => 'col-md-offset-2 col-md-6']],
             ['div' => ['class' => 'checkbox']],
             'input' => [
@@ -1265,7 +1276,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('published');
         $expected = [
-            'div' => ['class' => 'form-group'],
+            'div' => ['class' => 'form-group checkbox'],
             ['div' => ['class' => 'col-md-offset-2 col-md-6']],
             ['div' => ['class' => 'my-checkbox']],
             'input' => [
@@ -1566,7 +1577,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('published', ['help' => 'help text']);
         $expected = [
-            'div' => ['class' => 'form-check'],
+            'div' => ['class' => 'form-group checkbox'],
             'input' => [
                 'type' => 'hidden',
                 'name' => 'published',
@@ -1676,7 +1687,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('published', ['help' => 'help text']);
         $expected = [
-            'div' => ['class' => 'form-group'],
+            'div' => ['class' => 'form-group checkbox'],
             ['div' => ['class' => 'col-md-offset-2 col-md-6']],
             ['div' => ['class' => 'checkbox']],
             'input' => [

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -383,7 +383,7 @@ class FormHelperTest extends TestCase
             'label' => ['class' => 'col-form-label col-md-2', 'for' => 'title'],
             'Title',
             '/label',
-            ['div' => ['class' => 'col-md-6']],
+            ['div' => ['class' => 'col-md-10']],
             'input' => [
                 'type' => 'text',
                 'name' => 'title',
@@ -403,7 +403,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('published');
         $expected = [
             ['div' => ['class' => 'form-group row checkbox is-invalid']],
-            ['div' => ['class' => 'offset-md-2 col-md-6']],
+            ['div' => ['class' => 'offset-md-2 col-md-10']],
             ['div' => ['class' => 'checkbox']],
             ['input' => ['type' => 'hidden', 'name' => 'published', 'class' => 'is-invalid', 'value' => '0']],
             ['label' => ['for' => 'published']],
@@ -1141,7 +1141,7 @@ class FormHelperTest extends TestCase
             ],
             'Title',
             '/label',
-            ['div' => ['class' => 'col-md-6']],
+            ['div' => ['class' => 'col-md-10']],
             'input' => [
                 'type' => 'text',
                 'name' => 'title',
@@ -1157,7 +1157,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('published');
         $expected = [
             'div' => ['class' => 'form-group row checkbox'],
-            ['div' => ['class' => 'offset-md-2 col-md-6']],
+            ['div' => ['class' => 'offset-md-2 col-md-10']],
             ['div' => ['class' => 'checkbox']],
             'input' => [
                 'type' => 'hidden',
@@ -1261,7 +1261,7 @@ class FormHelperTest extends TestCase
             ],
             'Title',
             '/label',
-            ['div' => ['class' => 'col-md-6']],
+            ['div' => ['class' => 'col-md-10']],
             'input' => [
                 'type' => 'text',
                 'name' => 'title',
@@ -1277,7 +1277,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('published');
         $expected = [
             'div' => ['class' => 'form-group row checkbox'],
-            ['div' => ['class' => 'offset-md-2 col-md-6']],
+            ['div' => ['class' => 'offset-md-2 col-md-10']],
             ['div' => ['class' => 'my-checkbox']],
             'input' => [
                 'type' => 'hidden',
@@ -1377,7 +1377,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->submit('Submit');
         $expected = [
             'div' => ['class' => 'form-group'],
-            ['div' => ['class' => 'offset-md-2 col-md-6']],
+            ['div' => ['class' => 'offset-md-2 col-md-10']],
             'input' => [
                 'type' => 'submit',
                 'value' => 'Submit',
@@ -1669,7 +1669,7 @@ class FormHelperTest extends TestCase
             'label' => ['class' => 'col-form-label col-md-2', 'for' => 'title'],
             'Title',
             '/label',
-            ['div' => ['class' => 'col-md-6']],
+            ['div' => ['class' => 'col-md-10']],
             'input' => [
                 'type' => 'text',
                 'name' => 'title',
@@ -1688,7 +1688,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('published', ['help' => 'help text']);
         $expected = [
             'div' => ['class' => 'form-group row checkbox'],
-            ['div' => ['class' => 'offset-md-2 col-md-6']],
+            ['div' => ['class' => 'offset-md-2 col-md-10']],
             ['div' => ['class' => 'checkbox']],
             'input' => [
                 'type' => 'hidden',
@@ -1724,7 +1724,7 @@ class FormHelperTest extends TestCase
             'label' => ['class' => 'col-form-label col-md-2', 'for' => 'title'],
             'Title',
             '/label',
-            ['div' => ['class' => 'col-md-6']],
+            ['div' => ['class' => 'col-md-10']],
             'input' => [
                 'type' => 'text',
                 'name' => 'title',
@@ -1790,7 +1790,7 @@ class FormHelperTest extends TestCase
             'span' => ['data-toggle' => 'tooltip', 'title' => 'Some important additional notes.', 'class' => 'fas fa-info-circle'],
             '/span',
             '/label',
-            ['div' => ['class' => 'col-md-6']],
+            ['div' => ['class' => 'col-md-10']],
             'input' => [
                 'type' => 'text',
                 'name' => 'title',

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -403,7 +403,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('published');
         $expected = [
             ['div' => ['class' => 'form-group row checkbox is-invalid']],
-            ['div' => ['class' => 'col-md-offset-2 col-md-6']],
+            ['div' => ['class' => 'offset-md-2 col-md-6']],
             ['div' => ['class' => 'checkbox']],
             ['input' => ['type' => 'hidden', 'name' => 'published', 'class' => 'is-invalid', 'value' => '0']],
             ['label' => ['for' => 'published']],
@@ -1157,7 +1157,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('published');
         $expected = [
             'div' => ['class' => 'form-group row checkbox'],
-            ['div' => ['class' => 'col-md-offset-2 col-md-6']],
+            ['div' => ['class' => 'offset-md-2 col-md-6']],
             ['div' => ['class' => 'checkbox']],
             'input' => [
                 'type' => 'hidden',
@@ -1277,7 +1277,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('published');
         $expected = [
             'div' => ['class' => 'form-group row checkbox'],
-            ['div' => ['class' => 'col-md-offset-2 col-md-6']],
+            ['div' => ['class' => 'offset-md-2 col-md-6']],
             ['div' => ['class' => 'my-checkbox']],
             'input' => [
                 'type' => 'hidden',
@@ -1377,7 +1377,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->submit('Submit');
         $expected = [
             'div' => ['class' => 'form-group'],
-            ['div' => ['class' => 'col-md-offset-2 col-md-6']],
+            ['div' => ['class' => 'offset-md-2 col-md-6']],
             'input' => [
                 'type' => 'submit',
                 'value' => 'Submit',
@@ -1688,7 +1688,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('published', ['help' => 'help text']);
         $expected = [
             'div' => ['class' => 'form-group row checkbox'],
-            ['div' => ['class' => 'col-md-offset-2 col-md-6']],
+            ['div' => ['class' => 'offset-md-2 col-md-6']],
             ['div' => ['class' => 'checkbox']],
             'input' => [
                 'type' => 'hidden',

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -104,7 +104,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('title');
         $expected = [
             'div' => ['class' => 'form-group text'],
-            'label' => ['class' => 'col-form-label', 'for' => 'title'],
+            'label' => ['for' => 'title'],
             'Title',
             '/label',
             'input' => [
@@ -133,7 +133,7 @@ class FormHelperTest extends TestCase
         ]);
         $expected = [
             'div' => ['class' => 'form-group select'],
-            'label' => ['class' => 'col-form-label', 'for' => 'foreign-key'],
+            'label' => ['for' => 'foreign-key'],
             'Foreign Key',
             '/label',
             'select' => [
@@ -161,7 +161,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('title', ['type' => 'staticControl']);
         $expected = [
             'div' => ['class' => 'form-group staticControl'],
-            'label' => ['class' => 'col-form-label', 'for' => 'title'],
+            'label' => ['for' => 'title'],
             'Title',
             '/label',
             'p' => ['class' => 'form-control-plaintext'],
@@ -183,7 +183,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('title', ['type' => 'staticControl', 'hiddenField' => false, 'escape' => false]);
         $expected = [
             'div' => ['class' => 'form-group staticControl'],
-            'label' => ['class' => 'col-form-label', 'for' => 'title'],
+            'label' => ['for' => 'title'],
             'Title',
             '/label',
             'p' => ['class' => 'form-control-plaintext'],
@@ -235,7 +235,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('title', ['label' => 'Custom Title']);
         $expected = [
             'div' => ['class' => 'form-group text'],
-            'label' => ['class' => 'col-form-label', 'for' => 'title'],
+            'label' => ['for' => 'title'],
             'Custom Title',
             '/label',
             'input' => [
@@ -262,7 +262,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('title', ['label' => ['foo' => 'bar', 'text' => 'Custom Title']]);
         $expected = [
             'div' => ['class' => 'form-group text'],
-            'label' => ['class' => 'col-form-label', 'for' => 'title', 'foo' => 'bar'],
+            'label' => ['for' => 'title', 'foo' => 'bar'],
             'Custom Title',
             '/label',
             'input' => [
@@ -289,7 +289,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('password');
         $expected = [
             'div' => ['class' => 'form-group password'],
-            'label' => ['class' => 'col-form-label', 'for' => 'password'],
+            'label' => ['for' => 'password'],
             'Password',
             '/label',
             'input' => [
@@ -315,7 +315,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('title');
         $expected = [
             'div' => ['class' => 'form-group text required'],
-            'label' => ['class' => 'col-form-label', 'for' => 'title'],
+            'label' => ['for' => 'title'],
             'Title',
             '/label',
             'input' => [
@@ -346,7 +346,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('title');
         $expected = [
             'div' => ['class' => 'form-group text required is-invalid'],
-            'label' => ['class' => 'col-form-label', 'for' => 'title'],
+            'label' => ['for' => 'title'],
             'Title',
             '/label',
             'input' => [
@@ -417,7 +417,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('title', ['prepend' => '@']);
         $expected = [
             'div' => ['class' => 'form-group text required'],
-            'label' => ['class' => 'col-form-label', 'for' => 'title'],
+            'label' => ['for' => 'title'],
             'Title',
             '/label',
             ['div' => ['class' => 'input-group']],
@@ -441,7 +441,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('url', ['prepend' => 'http://']);
         $expected = [
             'div' => ['class' => 'form-group text'],
-            'label' => ['class' => 'col-form-label', 'for' => 'url'],
+            'label' => ['for' => 'url'],
             'Url',
             '/label',
             ['div' => ['class' => 'input-group']],
@@ -474,7 +474,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('title', ['append' => '@']);
         $expected = [
             'div' => ['class' => 'form-group text required'],
-            'label' => ['class' => 'col-form-label', 'for' => 'title'],
+            'label' => ['for' => 'title'],
             'Title',
             '/label',
             ['div' => ['class' => 'input-group']],
@@ -498,7 +498,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('title', ['append' => ['@', ['size' => 'lg']]]);
         $expected = [
             'div' => ['class' => 'form-group text required'],
-            'label' => ['class' => 'col-form-label', 'for' => 'title'],
+            'label' => ['for' => 'title'],
             'Title',
             '/label',
             ['div' => ['class' => 'input-group input-group-lg']],
@@ -532,7 +532,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('author_id', ['append' => '@']);
         $expected = [
             'div' => ['class' => 'form-group select required'],
-            'label' => ['class' => 'col-form-label', 'for' => 'author-id'],
+            'label' => ['for' => 'author-id'],
             'Author',
             '/label',
             ['div' => ['class' => 'input-group']],
@@ -569,7 +569,7 @@ class FormHelperTest extends TestCase
         ]);
         $expected = [
             'div' => ['class' => 'form-group textarea'],
-            'label' => ['class' => 'col-form-label', 'for' => 'body'],
+            'label' => ['for' => 'body'],
             'Body',
             '/label',
             ['div' => ['class' => 'input-group']],
@@ -603,7 +603,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('title', ['prepend' => $this->Form->button('GO')]);
         $expected = [
             'div' => ['class' => 'form-group text required'],
-            'label' => ['class' => 'col-form-label', 'for' => 'title'],
+            'label' => ['for' => 'title'],
             'Title',
             '/label',
             ['div' => ['class' => 'input-group']],
@@ -637,7 +637,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('title', ['append' => $this->Form->button('GO')]);
         $expected = [
             'div' => ['class' => 'form-group text required'],
-            'label' => ['class' => 'col-form-label', 'for' => 'title'],
+            'label' => ['for' => 'title'],
             'Title',
             '/label',
             ['div' => ['class' => 'input-group']],
@@ -1054,7 +1054,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('title');
         $expected = [
             'div' => ['class' => 'custom-container form-group'],
-            'label' => ['class' => 'col-form-label', 'for' => 'title'],
+            'label' => ['for' => 'title'],
             'Title',
             '/label',
             'input' => [
@@ -1527,7 +1527,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('title', ['help' => 'help text']);
         $expected = [
             'div' => ['class' => 'form-group text required'],
-            'label' => ['class' => 'col-form-label', 'for' => 'title'],
+            'label' => ['for' => 'title'],
             'Title',
             '/label',
             'input' => [
@@ -1547,7 +1547,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('title', ['help' => ['content' => 'help text', 'id' => 'test']]);
         $expected = [
             'div' => ['class' => 'form-group text required'],
-            'label' => ['class' => 'col-form-label', 'for' => 'title'],
+            'label' => ['for' => 'title'],
             'Title',
             '/label',
             'input' => [
@@ -1596,7 +1596,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('title', ['help' => 'help text']);
         $expected = [
             'div' => ['class' => 'form-group text required is-invalid'],
-            'label' => ['class' => 'col-form-label', 'for' => 'title'],
+            'label' => ['for' => 'title'],
             'Title',
             '/label',
             'input' => [
@@ -1622,7 +1622,7 @@ class FormHelperTest extends TestCase
         ]);
         $expected = [
             'div' => ['class' => 'form-group text required is-invalid'],
-            'label' => ['class' => 'col-form-label', 'for' => 'title'],
+            'label' => ['for' => 'title'],
             'Title',
             '/label',
             'input' => [
@@ -1745,7 +1745,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('title', ['tooltip' => 'Some important additional notes.']);
         $expected = [
             'div' => ['class' => 'form-group text required'],
-            'label' => ['class' => 'col-form-label', 'for' => 'title'],
+            'label' => ['for' => 'title'],
             'Title',
             'span' => ['data-toggle' => 'tooltip', 'title' => 'Some important additional notes.', 'class' => 'fas fa-info-circle'],
             '/span',

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -379,7 +379,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('title');
         $expected = [
-            'div' => ['class' => 'form-group text required is-invalid'],
+            'div' => ['class' => 'form-group row text required is-invalid'],
             'label' => ['class' => 'col-form-label col-md-2', 'for' => 'title'],
             'Title',
             '/label',
@@ -402,7 +402,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('published');
         $expected = [
-            ['div' => ['class' => 'form-group checkbox is-invalid']],
+            ['div' => ['class' => 'form-group row checkbox is-invalid']],
             ['div' => ['class' => 'col-md-offset-2 col-md-6']],
             ['div' => ['class' => 'checkbox']],
             ['input' => ['type' => 'hidden', 'name' => 'published', 'class' => 'is-invalid', 'value' => '0']],
@@ -796,7 +796,7 @@ class FormHelperTest extends TestCase
             'options' => ['Yes', 'No']
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group radio']],
+            ['div' => ['class' => 'form-group row radio']],
             ['label' => ['class' => 'col-form-label col-sm-5']],
             'Published',
             '/label',
@@ -856,7 +856,7 @@ class FormHelperTest extends TestCase
             'options' => ['Yes', 'No']
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group radio']],
+            ['div' => ['class' => 'form-group row radio']],
             ['label' => ['class' => 'col-form-label col-sm-5']],
             'Published',
             '/label',
@@ -1134,7 +1134,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('title');
         $expected = [
-            'div' => ['class' => 'form-group text required'],
+            'div' => ['class' => 'form-group row text required'],
             'label' => [
                 'class' => 'col-form-label col-md-2',
                 'for' => 'title'
@@ -1156,7 +1156,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('published');
         $expected = [
-            'div' => ['class' => 'form-group checkbox'],
+            'div' => ['class' => 'form-group row checkbox'],
             ['div' => ['class' => 'col-md-offset-2 col-md-6']],
             ['div' => ['class' => 'checkbox']],
             'input' => [
@@ -1197,7 +1197,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('title');
         $expected = [
-            'div' => ['class' => 'form-group text required'],
+            'div' => ['class' => 'form-group row text required'],
             'label' => [
                 'class' => 'col-form-label col-md-3',
                 'for' => 'title'
@@ -1254,7 +1254,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('title');
         $expected = [
-            'div' => ['class' => 'form-group text required'],
+            'div' => ['class' => 'form-group row text required'],
             'label' => [
                 'class' => 'col-form-label col-md-2',
                 'for' => 'title'
@@ -1276,7 +1276,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('published');
         $expected = [
-            'div' => ['class' => 'form-group checkbox'],
+            'div' => ['class' => 'form-group row checkbox'],
             ['div' => ['class' => 'col-md-offset-2 col-md-6']],
             ['div' => ['class' => 'my-checkbox']],
             'input' => [
@@ -1665,7 +1665,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('title', ['help' => 'help text']);
         $expected = [
-            'div' => ['class' => 'form-group text required'],
+            'div' => ['class' => 'form-group row text required'],
             'label' => ['class' => 'col-form-label col-md-2', 'for' => 'title'],
             'Title',
             '/label',
@@ -1687,7 +1687,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('published', ['help' => 'help text']);
         $expected = [
-            'div' => ['class' => 'form-group checkbox'],
+            'div' => ['class' => 'form-group row checkbox'],
             ['div' => ['class' => 'col-md-offset-2 col-md-6']],
             ['div' => ['class' => 'checkbox']],
             'input' => [
@@ -1720,7 +1720,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('title', ['help' => 'help text']);
         $expected = [
-            'div' => ['class' => 'form-group text required is-invalid'],
+            'div' => ['class' => 'form-group row text required is-invalid'],
             'label' => ['class' => 'col-form-label col-md-2', 'for' => 'title'],
             'Title',
             '/label',
@@ -1784,7 +1784,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('title', ['tooltip' => 'Some important additional notes.']);
         $expected = [
-            'div' => ['class' => 'form-group text required'],
+            'div' => ['class' => 'form-group row text required'],
             'label' => ['class' => 'col-form-label col-md-2', 'for' => 'title'],
             'Title ',
             'span' => ['data-toggle' => 'tooltip', 'title' => 'Some important additional notes.', 'class' => 'fas fa-info-circle'],

--- a/tests/test_app/TestApp/View/AppView.php
+++ b/tests/test_app/TestApp/View/AppView.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\View;
+namespace TestApp\View;
 
 use Cake\View\View;
 


### PR DESCRIPTION
Refs #223.

Following issues are fixes:

* Labels get the `col-form-label` class injected for non-horizontal forms.
* Checkbox wrappers in non-horizontal forms are missing the `is-invalid` class.
* Horizontal forms are missing the `row` class on the control wrapper `div`.
* Horizontal forms use a column width of `6` for inputs, the default should be `10`. The `right` configuration of the `grid` option that eats the remaining column width of `4`, is never used.
* The offset class used in horizontal forms uses the Bootstrap 3 name `col-%-offset-%`, it should be `offset-%-%` instead.
* `AppView` class in the test app pollutes the App namespace (can confuse IDEs).