### PR TITLE
Issue/223 - Breadcrumbs Helper

### DIFF
--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -6,14 +6,16 @@ use Cake\View\Helper\BreadcrumbsHelper as CoreBreadcrumbsHelper;
 class BreadcrumbsHelper extends CoreBreadcrumbsHelper
 {
     use OptionsAwareTrait;
+
     /**
      * @inheritdoc
      */
     protected $_defaultConfig = [
+        'ariaCurrent' => 'last',
         'templates' => [
             'wrapper' => '<nav aria-label="breadcrumb"><ol{{attrs}}>{{content}}</ol></nav>',
             'item' => '<li{{attrs}}><a href="{{url}}"{{innerAttrs}}>{{title}}</a></li>',
-            'itemWithoutLink' => '<li{{attrs}} aria-current="page"><span{{innerAttrs}}>{{title}}</span></li>',
+            'itemWithoutLink' => '<li{{attrs}}><span{{innerAttrs}}>{{title}}</span></li>',
             'separator' => ''
         ]
     ];
@@ -26,8 +28,7 @@ class BreadcrumbsHelper extends CoreBreadcrumbsHelper
     protected $_defaultAttributes = [
         'class' => [
             'wrapper' => 'breadcrumb',
-            'item' => 'breadcrumb-item',
-            'itemWithoutLink' => 'breadcrumb-item active'
+            'item' => 'breadcrumb-item'
         ]
     ];
 
@@ -37,6 +38,8 @@ class BreadcrumbsHelper extends CoreBreadcrumbsHelper
     public function render(array $attributes = [], array $separator = [])
     {
         $attributes = $this->injectClasses($this->_defaultAttributes['class']['wrapper'], $attributes);
+
+        $this->_injectAriaCurrentAttribute();
 
         return parent::render($attributes, $separator);
     }
@@ -49,5 +52,71 @@ class BreadcrumbsHelper extends CoreBreadcrumbsHelper
         $options = $this->injectClasses($this->_defaultAttributes['class']['item'], $options);
 
         return parent::add($title, $url, $options);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function prepend($title, $url = null, array $options = [])
+    {
+        $options = $this->injectClasses($this->_defaultAttributes['class']['item'], $options);
+
+        return parent::prepend($title, $url, $options);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function insertAt($index, $title, $url = null, array $options = [])
+    {
+        $options = $this->injectClasses($this->_defaultAttributes['class']['item'], $options);
+
+        return parent::insertAt($index, $title, $url, $options);
+    }
+
+    /**
+     * Injects the `aria-current` attribute into the current set of crumbs.
+     *
+     * @return void
+     */
+    protected function _injectAriaCurrentAttribute()
+    {
+        if ($this->crumbs) {
+            $this->_removeAriaCurrentAttribute();
+
+            $key = null;
+            if ($this->getConfig('ariaCurrent') === 'lastWithLink') {
+                foreach (array_reverse($this->crumbs, true) as $key => $crumb) {
+                    if (isset($crumb['url'])) {
+                        break;
+                    }
+                }
+            } else {
+                $key = count($this->crumbs) - 1;
+            }
+
+            if ($key) {
+                if (isset($this->crumbs[$key]['url'])) {
+                    $this->crumbs[$key]['options']['innerAttrs']['aria-current'] = 'page';
+                } else {
+                    $this->crumbs[$key]['options']['aria-current'] = 'page';
+                }
+            }
+        }
+    }
+
+    /**
+     * Removes the `aria-current` attribute from the current set of crumbs.
+     *
+     * @return void
+     */
+    protected function _removeAriaCurrentAttribute()
+    {
+        foreach ($this->crumbs as $key => $crumb) {
+            unset(
+                $this->crumbs[$key]['options']['innerAttrs']['aria-current'],
+                $this->crumbs[$key]['options']['aria-current']
+            );
+        }
     }
 }

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -81,27 +81,31 @@ class BreadcrumbsHelper extends CoreBreadcrumbsHelper
      */
     protected function _injectAriaCurrentAttribute()
     {
-        if ($this->crumbs) {
-            $this->_removeAriaCurrentAttribute();
+        if (!$this->crumbs) {
+            return;
+        }
 
-            $key = null;
-            if ($this->getConfig('ariaCurrent') === 'lastWithLink') {
-                foreach (array_reverse($this->crumbs, true) as $key => $crumb) {
-                    if (isset($crumb['url'])) {
-                        break;
-                    }
-                }
-            } else {
-                $key = count($this->crumbs) - 1;
-            }
+        $this->_removeAriaCurrentAttribute();
 
-            if ($key) {
-                if (isset($this->crumbs[$key]['url'])) {
-                    $this->crumbs[$key]['options']['innerAttrs']['aria-current'] = 'page';
-                } else {
-                    $this->crumbs[$key]['options']['aria-current'] = 'page';
+        $key = null;
+        if ($this->getConfig('ariaCurrent') === 'lastWithLink') {
+            foreach (array_reverse($this->crumbs, true) as $key => $crumb) {
+                if (isset($crumb['url'])) {
+                    break;
                 }
             }
+        } else {
+            $key = count($this->crumbs) - 1;
+        }
+
+        if (!$key) {
+            return;
+        }
+
+        if (isset($this->crumbs[$key]['url'])) {
+            $this->crumbs[$key]['options']['innerAttrs']['aria-current'] = 'page';
+        } else {
+            $this->crumbs[$key]['options']['aria-current'] = 'page';
         }
     }
 

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -22,11 +22,7 @@ class BreadcrumbsHelperTest extends TestCase
         parent::setUp();
 
         $this->View = new View();
-        if (class_exists('\Cake\View\Helper\BreadcrumbsHelper')) {
-            $this->Breadcrumbs = new BreadcrumbsHelper($this->View);
-        } else {
-            $this->markTestSkipped('BreadcrumbsHelper cannot be tested when core BreadcrumbsHelper class does not exist');
-        }
+        $this->Breadcrumbs = new BreadcrumbsHelper($this->View);
     }
 
     public function tearDown()

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace BootstrapUI\Test\TestCase\View\Helper;
 
+use BootstrapUI\View\Helper\BreadcrumbsHelper;
 use Cake\TestSuite\TestCase;
 use Cake\View\View;
 
@@ -12,7 +13,7 @@ class BreadcrumbsHelperTest extends TestCase
     public $View;
 
     /**
-     * @var HtmlHelper
+     * @var BreadcrumbsHelper
      */
     public $Breadcrumbs;
 
@@ -22,9 +23,9 @@ class BreadcrumbsHelperTest extends TestCase
 
         $this->View = new View();
         if (class_exists('\Cake\View\Helper\BreadcrumbsHelper')) {
-            $this->Breadcrumbs = new \BootstrapUI\View\Helper\BreadcrumbsHelper($this->View);
+            $this->Breadcrumbs = new BreadcrumbsHelper($this->View);
         } else {
-            $this->Breadcrumbs = null;
+            $this->markTestSkipped('BreadcrumbsHelper cannot be tested when core BreadcrumbsHelper class does not exist');
         }
     }
 
@@ -36,26 +37,62 @@ class BreadcrumbsHelperTest extends TestCase
 
     public function testCrumbList()
     {
-        if (!class_exists('\Cake\View\Helper\BreadcrumbsHelper')) {
-            $this->markTestSkipped('BreadcrumbsHelper cannot be tested when core BreadcrumbsHelper class does not exist');
-        }
-
         $result = $this->Breadcrumbs
             ->add('jadb')
             ->add('admad')
             ->add('joe')
+            ->prepend('first')
+            ->insertAt(2, 'at index 2')
+            ->insertAfter('admad', 'after admad')
+            ->insertBefore('joe', 'before joe')
             ->render();
 
-        $expected = '<nav aria-label="breadcrumb"><ol class="breadcrumb"><li class="breadcrumb-item" aria-current="page"><span>jadb</span></li><li class="breadcrumb-item" aria-current="page"><span>admad</span></li><li class="breadcrumb-item" aria-current="page"><span>joe</span></li></ol></nav>';
-        $this->assertEquals($expected, $result);
+        $expected = [
+            'nav' => ['aria-label' => 'breadcrumb'],
+                'ol' => ['class' => 'breadcrumb'],
+                    ['li' => ['class' => 'breadcrumb-item']],
+                        ['span' => true],
+                        'first',
+                        '/span',
+                    '/li',
+                    ['li' => ['class' => 'breadcrumb-item']],
+                        ['span' => true],
+                        'jadb',
+                        '/span',
+                    '/li',
+                    ['li' => ['class' => 'breadcrumb-item']],
+                        ['span' => true],
+                        'at index 2',
+                        '/span',
+                    '/li',
+                    ['li' => ['class' => 'breadcrumb-item']],
+                        ['span' => true],
+                        'admad',
+                        '/span',
+                    '/li',
+                    ['li' => ['class' => 'breadcrumb-item']],
+                        ['span' => true],
+                        'after admad',
+                        '/span',
+                    '/li',
+                    ['li' => ['class' => 'breadcrumb-item']],
+                        ['span' => true],
+                        'before joe',
+                        '/span',
+                    '/li',
+                    ['li' => ['class' => 'breadcrumb-item', 'aria-current' => 'page']],
+                        ['span' => true],
+                        'joe',
+                        '/span',
+                    '/li',
+                '/ol',
+            '/nav'
+        ];
+        $this->assertHtml($expected, $result);
     }
 
     public function testAttributes()
     {
-        if (!class_exists('\Cake\View\Helper\BreadcrumbsHelper')) {
-            $this->markTestSkipped('BreadcrumbsHelper cannot be tested when core BreadcrumbsHelper class does not exist');
-        }
-
         $attributes = [
             'wrapper' => ['class' => 'wrapper-class'],
             'separator' => ['class' => 'separator-class', 'innerAttrs' => ['class' => 'separator-inner-class']],
@@ -65,10 +102,112 @@ class BreadcrumbsHelperTest extends TestCase
 
         $result = $this->Breadcrumbs
             ->add('joe', null, $attributes['itemWithoutLink'])
-            ->add('black', '/foo/bar', $attributes['itemWithoutLink'])
+            ->add('black', '/foo/bar', $attributes['item'])
             ->render($attributes['wrapper'], $attributes['separator']);
 
-        $expected = '<nav aria-label="breadcrumb"><ol class="wrapper-class breadcrumb"><li class="itemWithoutLink-class breadcrumb-item" aria-current="page"><span class="itemWithoutLink-inner-class">joe</span></li><li class="itemWithoutLink-class breadcrumb-item"><a href="/foo/bar" class="itemWithoutLink-inner-class">black</a></li></ol></nav>';
-        $this->assertEquals($expected, $result);
+        $expected = [
+            'nav' => ['aria-label' => 'breadcrumb'],
+                'ol' => ['class' => 'wrapper-class breadcrumb'],
+                    ['li' => ['class' => 'itemWithoutLink-class breadcrumb-item']],
+                        ['span' => ['class' => 'itemWithoutLink-inner-class']],
+                        'joe',
+                        '/span',
+                    '/li',
+                    ['li' => ['class' => 'item-class breadcrumb-item']],
+                        ['a' => ['href' => '/foo/bar', 'class' => 'item-inner-class', 'aria-current' => 'page']],
+                            'black',
+                        '/a',
+                    '/li',
+                '/ol',
+            '/nav'
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testAriaCurrentLastWithLink()
+    {
+        $this->Breadcrumbs->setConfig('ariaCurrent', 'lastWithLink');
+
+        $result = $this->Breadcrumbs
+            ->add('first')
+            ->add('last with link', '/foo/bar')
+            ->add('last')
+            ->render();
+
+        $expected = [
+            'nav' => ['aria-label' => 'breadcrumb'],
+                'ol' => ['class' => 'breadcrumb'],
+                    ['li' => ['class' => 'breadcrumb-item']],
+                        ['span' => true],
+                        'first',
+                        '/span',
+                    '/li',
+                    ['li' => ['class' => 'breadcrumb-item']],
+                        ['a' => ['href' => '/foo/bar', 'aria-current' => 'page']],
+                            'last with link',
+                        '/a',
+                    '/li',
+                    ['li' => ['class' => 'breadcrumb-item']],
+                        ['span' => true],
+                        'last',
+                        '/span',
+                    '/li',
+                '/ol',
+            '/nav'
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testAriaCurrentRemoveAndInject()
+    {
+        $result = $this->Breadcrumbs
+            ->add('first')
+            ->add('second')
+            ->render();
+
+        $expected = [
+            'nav' => ['aria-label' => 'breadcrumb'],
+                'ol' => ['class' => 'breadcrumb'],
+                    ['li' => ['class' => 'breadcrumb-item']],
+                        ['span' => true],
+                        'first',
+                        '/span',
+                    '/li',
+                    ['li' => ['class' => 'breadcrumb-item', 'aria-current' => 'page']],
+                        ['span' => true],
+                        'second',
+                        '/span',
+                    '/li',
+                '/ol',
+            '/nav'
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Breadcrumbs
+            ->add('third')
+            ->render();
+
+        $expected = [
+            'nav' => ['aria-label' => 'breadcrumb'],
+                'ol' => ['class' => 'breadcrumb'],
+                    ['li' => ['class' => 'breadcrumb-item']],
+                        ['span' => true],
+                        'first',
+                        '/span',
+                    '/li',
+                    ['li' => ['class' => 'breadcrumb-item']],
+                        ['span' => true],
+                        'second',
+                        '/span',
+                    '/li',
+                    ['li' => ['class' => 'breadcrumb-item', 'aria-current' => 'page']],
+                        ['span' => true],
+                        'third',
+                        '/span',
+                    '/li',
+                '/ol',
+            '/nav'
+        ];
+        $this->assertHtml($expected, $result);
     }
 }

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -158,6 +158,34 @@ class BreadcrumbsHelperTest extends TestCase
         $this->assertHtml($expected, $result);
     }
 
+    public function testAriaCurrentLastWithLinkNoCrumbWithLink()
+    {
+        $this->Breadcrumbs->setConfig('ariaCurrent', 'lastWithLink');
+
+        $result = $this->Breadcrumbs
+            ->add('first')
+            ->add('second')
+            ->render();
+
+        $expected = [
+            'nav' => ['aria-label' => 'breadcrumb'],
+                'ol' => ['class' => 'breadcrumb'],
+                    ['li' => ['class' => 'breadcrumb-item']],
+                        ['span' => true],
+                        'first',
+                        '/span',
+                    '/li',
+                    ['li' => ['class' => 'breadcrumb-item']],
+                        ['span' => true],
+                        'second',
+                        '/span',
+                    '/li',
+                '/ol',
+            '/nav'
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testAriaCurrentRemoveAndInject()
     {
         $result = $this->Breadcrumbs
@@ -209,5 +237,11 @@ class BreadcrumbsHelperTest extends TestCase
             '/nav'
         ];
         $this->assertHtml($expected, $result);
+    }
+
+    public function testNoCrumbs()
+    {
+        $result = $this->Breadcrumbs->render();
+        $this->assertEmpty($result);
     }
 }


### PR DESCRIPTION
Adds missing overrides to ensure bootstrap classes are added for all
crumb insertion methods.

Ensures that the `aria-current` attribute is only applied to one crumb,
either the last one (default), or the last one with a link, and that for
crumbs with links the attribute is set on the link.

refs #223