### PR TITLE
Fix : display alert

### DIFF
--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -20,7 +20,7 @@ class FlashHelper extends Helper
      * @var array
      */
     protected $_defaultConfig = [
-        'class' => ['alert', 'alert-dismissible', 'fade', 'in'],
+        'class' => ['alert', 'alert-dismissible', 'fade', 'show'],
         'attributes' => ['role' => 'alert'],
         'element' => 'BootstrapUI.Flash/default'
     ];


### PR DESCRIPTION
In BS4, the .in class is now .show

## Description
Replace in FlashHelper class .in by class .show

## Summarize
- Replace in by show in FlashHelper

## Benefits
Alert now display properly