### PR TITLE
Replace deprecated method ConsoleOptionParser::description()

### DIFF
--- a/src/Shell/BootstrapShell.php
+++ b/src/Shell/BootstrapShell.php
@@ -70,7 +70,7 @@ class BootstrapShell extends Shell
     {
         $parser = parent::getOptionParser();
 
-        return $parser->description([
+        return $parser->setDescription([
             'Bootstrap Shell',
             '',
             ''


### PR DESCRIPTION
## Description
`ConsoleOptionParser::description()` has been deprecated at 3.4.0.
> @deprecated 3.4.0 Use setDescription()/getDescription() instead.

## Summarize
- Replaced `description()`  to `setDescription()`