### PR TITLE
Get always minified assets.

### DIFF
--- a/src/Template/Layout/default.ctp
+++ b/src/Template/Layout/default.ctp
@@ -73,14 +73,14 @@ $this->prepend('meta', $this->Html->meta('favicon.ico', '/favicon.ico', ['type' 
  * Prepend `css` block with Bootstrap stylesheets
  * Change to bootstrap.min to use the compressed version
  */
-$this->prepend('css', $this->Html->css(['BootstrapUI.bootstrap']));
+$this->prepend('css', $this->Html->css(['BootstrapUI.bootstrap.min']));
 
 
 /**
  * Prepend `script` block with jQuery, Popper and Bootstrap scripts
  * Change jquery.min and bootstrap.min to use the compressed version
  */
-$this->prepend('script', $this->Html->script(['BootstrapUI.jquery', 'BootstrapUI.popper', 'BootstrapUI.bootstrap']));
+$this->prepend('script', $this->Html->script(['BootstrapUI.jquery.min', 'BootstrapUI.popper.min', 'BootstrapUI.bootstrap.min']));
 
 ?>
 <!doctype html>


### PR DESCRIPTION
## Description
Changed to get minified css and scripts in `default.ctp` by default.
If debug is false `bin/cake bootstrap install` installs assets only minified one.
But templates still render non-minified file path, So gets 404 error with those. 