### PR TITLE
Update FormHelper.php

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -63,8 +63,8 @@ class FormHelper extends Helper
      */
     protected $_templateSet = [
         'default' => [
-            'checkboxContainer' => '<div class="form-group {{type}}{{required}}">{{content}}{{help}}</div>',
-            'checkboxContainerError' => '<div class="form-group {{type}}{{required}} is-invalid">{{content}}{{error}}{{help}}</div>',
+            'checkboxContainer' => '<div class="form-group form-check {{type}}{{required}}">{{content}}{{help}}</div>',
+            'checkboxContainerError' => '<div class="form-group form-check {{type}}{{required}} is-invalid">{{content}}{{error}}{{help}}</div>',
         ],
         'inline' => [
             'label' => '<label class="sr-only"{{attrs}}>{{text}}{{tooltip}}</label>',
@@ -253,6 +253,11 @@ class FormHelper extends Helper
                         $options['templates']['checkboxContainer'] = '{{content}}';
                     }
                 }
+
+                $options['templates']['nestingLabel'] = '{{hidden}}{{input}}<label{{attrs}}>{{text}}</label>';
+                $options['label'] = $this->injectClasses('form-check-label', (array)$options['label']);
+                $options = $this->injectClasses('form-check-input', (array)$options);
+
                 unset($options['inline']);
                 break;
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -53,6 +53,7 @@ class FormHelper extends Helper
         'inputGroupAddon' => '<div class="{{class}}">{{content}}</div>',
         'inputGroupContainer' => '<div{{attrs}}>{{prepend}}{{content}}{{append}}</div>',
         'inputGroupText' => '<span class="input-group-text">{{content}}</span>',
+        'checkboxFormGroup' => '{{input}}{{label}}',
         'file' => '<input type="file" class="form-control-file" name="{{name}}"{{attrs}}>'
     ];
 
@@ -254,7 +255,7 @@ class FormHelper extends Helper
                     }
                 }
 
-                $options['templates']['nestingLabel'] = '{{hidden}}{{input}}<label{{attrs}}>{{text}}</label>';
+                $options['nestedInput'] = false;
                 $options['label'] = $this->injectClasses('form-check-label', (array)$options['label']);
                 $options = $this->injectClasses('form-check-input', (array)$options);
 


### PR DESCRIPTION
Refs #223 

So i'm trying bootstrap 4 with cake and stumbled upon the following problem:
- Labels/inputs for checkboxes and radiobuttons are missing the `form-check-label/form-check-input` class.

I made a quick and dirty solution for checkboxes which works for me.
It adds the proper classes and moves the input outside of the label without having to mess with `nestedInput`.

Maybe the same could be done for radios, but I haven't touched those yet.