### PR TITLE
Make submit button 'primary' by default

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -189,6 +189,9 @@ class FormHelper extends Helper
      */
     public function submit($caption = null, array $options = [])
     {
+        $options += [
+            'class' => 'primary'
+        ];
         $options = $this->applyButtonClasses($options);
 
         return parent::submit($caption, $options);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -1293,7 +1293,7 @@ class FormHelperTest extends TestCase
             'input' => [
                 'type' => 'submit',
                 'value' => 'Submit',
-                'class' => 'btn btn-primary'
+                'class' => 'btn btn-primary',
             ]
         ];
         $this->assertHtml($expected, $result);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -1293,7 +1293,7 @@ class FormHelperTest extends TestCase
             'input' => [
                 'type' => 'submit',
                 'value' => 'Submit',
-                'class' => 'btn btn-primary',
+                'class' => 'btn btn-primary'
             ]
         ];
         $this->assertHtml($expected, $result);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -1293,7 +1293,7 @@ class FormHelperTest extends TestCase
             'input' => [
                 'type' => 'submit',
                 'value' => 'Submit',
-                'class' => 'btn btn-primary',
+                'class' => 'btn-primary btn',
             ]
         ];
         $this->assertHtml($expected, $result);
@@ -1345,7 +1345,7 @@ class FormHelperTest extends TestCase
             'input' => [
                 'type' => 'submit',
                 'value' => 'Submit',
-                'class' => 'btn btn-primary',
+                'class' => 'btn-primary btn',
             ]
         ];
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -1293,7 +1293,7 @@ class FormHelperTest extends TestCase
             'input' => [
                 'type' => 'submit',
                 'value' => 'Submit',
-                'class' => 'btn btn-secondary',
+                'class' => 'btn btn-primary',
             ]
         ];
         $this->assertHtml($expected, $result);
@@ -1345,7 +1345,7 @@ class FormHelperTest extends TestCase
             'input' => [
                 'type' => 'submit',
                 'value' => 'Submit',
-                'class' => 'btn btn-secondary',
+                'class' => 'btn btn-primary',
             ]
         ];
 


### PR DESCRIPTION
Refs #223 

- [x] Maybe submit buttons (those created via FormHelper::submit()) could use the btn-primary class by default. At least personally I've found myself to always switch to that.

ping @ndm2