### PR TITLE
Use newer, non-deprecated method

### DIFF
--- a/src/Template/Layout/default.ctp
+++ b/src/Template/Layout/default.ctp
@@ -32,7 +32,7 @@ if (!$this->fetch('tb_footer')) {
 /**
  * Default `body` block.
  */
-$this->prepend('tb_body_attrs', ' class="' . implode(' ', [$this->request->controller, $this->request->action]) . '" ');
+$this->prepend('tb_body_attrs', ' class="' . implode(' ', [$this->request->getParam('controller'), $this->request->getParam('action')]) . '" ');
 if (!$this->fetch('tb_body_start')) {
     $this->start('tb_body_start');
     echo '<body' . $this->fetch('tb_body_attrs') . '>';

--- a/src/Template/Layout/default.ctp
+++ b/src/Template/Layout/default.ctp
@@ -43,8 +43,9 @@ if (!$this->fetch('tb_body_start')) {
  */
 if (!$this->fetch('tb_flash')) {
     $this->start('tb_flash');
-    if (isset($this->Flash))
+    if (isset($this->Flash)) {
         echo $this->Flash->render();
+    }
     $this->end();
 }
 if (!$this->fetch('tb_body_end')) {

--- a/src/Template/Layout/examples/cover.ctp
+++ b/src/Template/Layout/examples/cover.ctp
@@ -3,7 +3,7 @@
 use Cake\Core\Configure;
 
 $this->Html->css('BootstrapUI.cover', ['block' => true]);
-$this->prepend('tb_body_attrs', ' class="' . implode(' ', [$this->request->getParam('controller'), $this->request->action]) . '" ');
+$this->prepend('tb_body_attrs', ' class="' . implode(' ', [$this->request->getParam('controller'), $this->request->getParam('action')]) . '" ');
 $this->start('tb_body_start');
 ?>
 <body <?= $this->fetch('tb_body_attrs') ?>>

--- a/src/Template/Layout/examples/cover.ctp
+++ b/src/Template/Layout/examples/cover.ctp
@@ -3,7 +3,7 @@
 use Cake\Core\Configure;
 
 $this->Html->css('BootstrapUI.cover', ['block' => true]);
-$this->prepend('tb_body_attrs', ' class="' . implode(' ', [$this->request->controller, $this->request->action]) . '" ');
+$this->prepend('tb_body_attrs', ' class="' . implode(' ', [$this->request->getParam('controller'), $this->request->action]) . '" ');
 $this->start('tb_body_start');
 ?>
 <body <?= $this->fetch('tb_body_attrs') ?>>
@@ -25,8 +25,9 @@ $this->start('tb_body_start');
  */
 if (!$this->fetch('tb_flash')) {
     $this->start('tb_flash');
-    if (isset($this->Flash))
+    if (isset($this->Flash)) {
         echo $this->Flash->render();
+    }
     $this->end();
 }
 $this->end();

--- a/src/Template/Layout/examples/dashboard.ctp
+++ b/src/Template/Layout/examples/dashboard.ctp
@@ -3,7 +3,7 @@
 use Cake\Core\Configure;
 
 $this->Html->css('BootstrapUI.dashboard', ['block' => true]);
-$this->prepend('tb_body_attrs', ' class="' . implode(' ', [$this->request->controller, $this->request->action]) . '" ');
+$this->prepend('tb_body_attrs', ' class="' . implode(' ', [$this->request->getParam('controller'), $this->request->getParam('action')]) . '" ');
 $this->start('tb_body_start');
 ?>
 <body <?= $this->fetch('tb_body_attrs') ?>>
@@ -44,15 +44,16 @@ $this->start('tb_body_start');
                 <?= $this->fetch('tb_sidebar') ?>
             </div>
             <div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">
-                <h1 class="page-header"><?= $this->request->controller; ?></h1>
+                <h1 class="page-header"><?= $this->request->getParam('controller'); ?></h1>
 <?php
 /**
  * Default `flash` block.
  */
 if (!$this->fetch('tb_flash')) {
     $this->start('tb_flash');
-    if (isset($this->Flash))
+    if (isset($this->Flash)) {
         echo $this->Flash->render();
+    }
     $this->end();
 }
 $this->end();

--- a/src/Template/Layout/examples/signin.ctp
+++ b/src/Template/Layout/examples/signin.ctp
@@ -1,15 +1,16 @@
 <?php
 /* @var $this \Cake\View\View */
 $this->Html->css('BootstrapUI.signin', ['block' => true]);
-$this->prepend('tb_body_attrs', ' class="' . implode(' ', [$this->request->controller, $this->request->action]) . '" ');
+$this->prepend('tb_body_attrs', ' class="' . implode(' ', [$this->request->getParam('controller'), $this->request->getParam('action')]) . '" ');
 $this->start('tb_body_start');
 /**
  * Default `flash` block.
  */
 if (!$this->fetch('tb_flash')) {
     $this->start('tb_flash');
-    if (isset($this->Flash))
+    if (isset($this->Flash)) {
         echo $this->Flash->render();
+    }
     $this->end();
 }
 ?>


### PR DESCRIPTION
Use the newer getParam instead of older direct access of controller from view.

## Description
Use the newer getParam instead of older direct access of controller from view.

## Summarize
Just changed the two occurences in the file default.ctp

## Benefits
No deprecation warnings when changed.
