### PR TITLE
fix Deprecated(16384) Accessing routing parameters will removed in 4.0.0

### DIFF
--- a/src/Template/Layout/default.ctp
+++ b/src/Template/Layout/default.ctp
@@ -32,7 +32,7 @@ if (!$this->fetch('tb_footer')) {
 /**
  * Default `body` block.
  */
-$this->prepend('tb_body_attrs', ' class="' . implode(' ', [$this->request->controller, $this->request->action]) . '" ');
+$this->prepend('tb_body_attrs', ' class="' . implode(' ', [$this->request->getParam('controller'), $this->request->getParam('action')]) . '" ');
 if (!$this->fetch('tb_body_start')) {
     $this->start('tb_body_start');
     echo '<body' . $this->fetch('tb_body_attrs') . '>';

--- a/src/Template/Layout/examples/cover.ctp
+++ b/src/Template/Layout/examples/cover.ctp
@@ -3,7 +3,7 @@
 use Cake\Core\Configure;
 
 $this->Html->css('BootstrapUI.cover', ['block' => true]);
-$this->prepend('tb_body_attrs', ' class="' . implode(' ', [$this->request->controller, $this->request->action]) . '" ');
+$this->prepend('tb_body_attrs', ' class="' . implode(' ', [$this->request->getParam('controller'), $this->request->getParam('action')]) . '" ');
 $this->start('tb_body_start');
 ?>
 <body <?= $this->fetch('tb_body_attrs') ?>>

--- a/src/Template/Layout/examples/dashboard.ctp
+++ b/src/Template/Layout/examples/dashboard.ctp
@@ -3,7 +3,7 @@
 use Cake\Core\Configure;
 
 $this->Html->css('BootstrapUI.dashboard', ['block' => true]);
-$this->prepend('tb_body_attrs', ' class="' . implode(' ', [$this->request->controller, $this->request->action]) . '" ');
+$this->prepend('tb_body_attrs', ' class="' . implode(' ', [$this->request->getParam('controller'), $this->request->getParam('action')]) . '" ');
 $this->start('tb_body_start');
 ?>
 <body <?= $this->fetch('tb_body_attrs') ?>>
@@ -44,7 +44,7 @@ $this->start('tb_body_start');
                 <?= $this->fetch('tb_sidebar') ?>
             </div>
             <div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">
-                <h1 class="page-header"><?= $this->request->controller; ?></h1>
+                <h1 class="page-header"><?= $this->request->getParam('controller'); ?></h1>
 <?php
 /**
  * Default `flash` block.

--- a/src/Template/Layout/examples/signin.ctp
+++ b/src/Template/Layout/examples/signin.ctp
@@ -1,7 +1,7 @@
 <?php
 /* @var $this \Cake\View\View */
 $this->Html->css('BootstrapUI.signin', ['block' => true]);
-$this->prepend('tb_body_attrs', ' class="' . implode(' ', [$this->request->controller, $this->request->action]) . '" ');
+$this->prepend('tb_body_attrs', ' class="' . implode(' ', [$this->request->getParam('controller'), $this->request->getParam('action')]) . '" ');
 $this->start('tb_body_start');
 /**
  * Default `flash` block.


### PR DESCRIPTION
## Description
Change the reference `$this->request->controller` and `$this->request->action` due to related of Deprecated (16384) of CakePHP framework and will be removed in CakePHP v 4.0.0

## Summarize
Replace them with `$this->request->getParam('controller')` and `$this->request->getParam('action')`, that is suggested by the framework description belong with the warning messages.

- Find the same occurrences of `$this->request->controller` and replace with `$this->request->getParam('controller')`.
- Find the same occurrences of `$this->request->action` and replace with `$this->request->getParam('action')`.

## Benefits
Remove the deprecated #16384 warning of CakePHP 3.6.12 and this deprecated accessing routing will be remove in CakePHP 4.0.0.

## Related Issues
[bootstrap-ui/issues/238](https://github.com/FriendsOfCake/bootstrap-ui/issues/238)
