### PR TITLE
BS4 Compatibility - Multi Checkbox Control

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -60,9 +60,11 @@ class FormHelper extends Helper
         'inputGroupContainer' => '<div{{attrs}}>{{prepend}}{{content}}{{append}}</div>',
         'inputGroupText' => '<span class="input-group-text">{{content}}</span>',
         'file' => '<input type="file" class="form-control-file" name="{{name}}"{{attrs}}>',
-        'multicheckboxContainer' => '<fieldset class="form-group {{type}}{{required}}">{{content}}{{help}}</fieldset>',
-        'multicheckboxContainerError' => '<fieldset class="form-group {{type}}{{required}} is-invalid">{{content}}{{error}}{{help}}</fieldset>',
-        'multicheckboxLegend' => '<legend>{{text}}</legend>',
+        'multicheckboxContainer' => '<div class="form-group {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}{{help}}</div>',
+        'multicheckboxContainerError' => '<div class="form-group {{type}}{{required}} is-invalid" role="group" aria-labelledby="{{groupId}}">{{content}}{{error}}{{help}}</div>',
+        'multicheckboxLabel' => '<label id="{{groupId}}" class="d-block">{{text}}</label>',
+        'multicheckboxWrapper' => '<fieldset class="form-group">{{content}}</fieldset>',
+        'multicheckboxTitle' => '<legend class="col-form-label pt-0">{{text}}</legend>',
         'nestingLabel' => '{{hidden}}{{input}}<label{{attrs}}>{{text}}{{tooltip}}</label>',
         'nestingLabelNestedInput' => '{{hidden}}<label{{attrs}}>{{input}}{{text}}{{tooltip}}</label>',
     ];
@@ -78,9 +80,9 @@ class FormHelper extends Helper
         'inline' => [
             'label' => '<label class="sr-only"{{attrs}}>{{text}}{{tooltip}}</label>',
             'inputContainer' => '{{content}}',
-            'multicheckboxContainer' => '<div class="form-group {{type}}{{required}}">{{content}}</div>',
-            'multicheckboxContainerError' => '<div class="form-group {{type}}{{required}} is-invalid">{{content}}</div>',
-            'multicheckboxLegend' => '<span class="sr-only">{{text}}</span>',
+            'multicheckboxContainer' => '<div class="form-group {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
+            'multicheckboxContainerError' => '<div class="form-group {{type}}{{required}} is-invalid" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
+            'multicheckboxLabel' => '<span id="{{groupId}}" class="sr-only">{{text}}</span>',
         ],
         'horizontal' => [
             'label' => '<label class="col-form-label %s"{{attrs}}>{{text}}{{tooltip}}</label>',
@@ -95,9 +97,9 @@ class FormHelper extends Helper
             'radioContainer' => '<div class="form-group row {{type}}{{required}}">{{content}}</div>',
             'radioContainerError' => '<div class="form-group row {{type}}{{required}} is-invalid">{{content}}</div>',
             'radioInlineWrapper' => '<div class="form-check form-check-inline">{{hidden}}{{label}}</div>',
-            'multicheckboxContainer' => '<fieldset class="form-group {{type}}{{required}}"><div class="row">{{content}}</div></fieldset>',
-            'multicheckboxContainerError' => '<fieldset class="form-group {{type}}{{required}} is-invalid"><div class="row">{{content}}</div></fieldset>',
-            'multicheckboxLegend' => '<legend class="col-form-label pt-0 %s">{{text}}</legend>',
+            'multicheckboxContainer' => '<div class="form-group {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}"><div class="row">{{content}}</div></div>',
+            'multicheckboxContainerError' => '<div class="form-group {{type}}{{required}} is-invalid" role="group" aria-labelledby="{{groupId}}"><div class="row">{{content}}</div></div>',
+            'multicheckboxLabel' => '<label id="{{groupId}}" class="col-form-label d-block pt-0 %s">{{text}}</label>',
         ]
     ];
 
@@ -326,7 +328,8 @@ class FormHelper extends Helper
                 }
 
                 if ($options['type'] === 'multicheckbox') {
-                    $options['templates']['label'] = $this->templater()->get('multicheckboxLegend');
+                    $options['templateVars']['groupId'] = $this->_domId($fieldName . '-group-label');
+                    $options['templates']['label'] = $this->templater()->get('multicheckboxLabel');
 
                     if ($options['inline'] ||
                         $this->_align === 'inline'
@@ -652,7 +655,7 @@ class FormHelper extends Helper
         $offsetedGridClass = implode(' ', [$this->_gridClass('left', true), $this->_gridClass('middle')]);
 
         $templates['label'] = sprintf($templates['label'], $this->_gridClass('left'));
-        $templates['multicheckboxLegend'] = sprintf($templates['multicheckboxLegend'], $this->_gridClass('left'));
+        $templates['multicheckboxLabel'] = sprintf($templates['multicheckboxLabel'], $this->_gridClass('left'));
         $templates['formGroup'] = sprintf($templates['formGroup'], $this->_gridClass('middle'));
         foreach (['checkboxFormGroup', 'submitContainer'] as $value) {
             $templates[$value] = sprintf($templates[$value], $offsetedGridClass);

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -250,6 +250,7 @@ class FormHelper extends Helper
             'prepend' => null,
             'append' => null,
             'inline' => null,
+            'nestedInput' => false,
             'type' => null,
             'label' => null,
             'error' => null,
@@ -264,13 +265,8 @@ class FormHelper extends Helper
         $options = $this->_parseOptions($fieldName, $options);
 
         $inline = $options['inline'];
-        unset($options['inline']);
-
-        if (!isset($options['nestedInput'])) {
-            $options['nestedInput'] = false;
-        }
         $nestedInput = $options['nestedInput'];
-        unset($options['nestedInput']);
+        unset($options['inline'], $options['nestedInput']);
 
         $newTemplates = $options['templates'];
         if ($newTemplates) {

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -50,15 +50,21 @@ class FormHelper extends Helper
         'checkboxContainer' => '<div class="form-group form-check {{type}}{{required}}">{{content}}{{help}}</div>',
         'checkboxContainerError' => '<div class="form-group form-check {{type}}{{required}} is-invalid">{{content}}{{error}}{{help}}</div>',
         'checkboxFormGroup' => '{{input}}{{label}}',
-        'checkboxWrapper' => '<div class="form-check">{{input}}{{label}}</div>',
-        'radioWrapper' => '<div class="form-check">{{hidden}}{{input}}{{label}}</div>',
+        'checkboxWrapper' => '<div class="form-check">{{label}}</div>',
+        'checkboxInlineWrapper' => '<div class="form-check form-check-inline">{{label}}</div>',
+        'radioWrapper' => '<div class="form-check">{{hidden}}{{label}}</div>',
         'radioInlineFormGroup' => '{{label}}<div class="form-check form-check-inline">{{input}}</div>',
         'radioNestingLabel' => '<div class="form-check">{{hidden}}<label{{attrs}}>{{input}}{{text}}{{tooltip}}</label></div>',
         'staticControl' => '<p class="form-control-plaintext">{{content}}</p>',
         'inputGroupAddon' => '<div class="{{class}}">{{content}}</div>',
         'inputGroupContainer' => '<div{{attrs}}>{{prepend}}{{content}}{{append}}</div>',
         'inputGroupText' => '<span class="input-group-text">{{content}}</span>',
-        'file' => '<input type="file" class="form-control-file" name="{{name}}"{{attrs}}>'
+        'file' => '<input type="file" class="form-control-file" name="{{name}}"{{attrs}}>',
+        'multicheckboxContainer' => '<fieldset class="form-group {{type}}{{required}}">{{content}}{{help}}</fieldset>',
+        'multicheckboxContainerError' => '<fieldset class="form-group {{type}}{{required}} is-invalid">{{content}}{{error}}{{help}}</fieldset>',
+        'multicheckboxLegend' => '<legend>{{text}}</legend>',
+        'nestingLabel' => '{{hidden}}{{input}}<label{{attrs}}>{{text}}{{tooltip}}</label>',
+        'nestingLabelNestedInput' => '{{hidden}}<label{{attrs}}>{{input}}{{text}}{{tooltip}}</label>',
     ];
 
     /**
@@ -71,7 +77,10 @@ class FormHelper extends Helper
         ],
         'inline' => [
             'label' => '<label class="sr-only"{{attrs}}>{{text}}{{tooltip}}</label>',
-            'inputContainer' => '{{content}}'
+            'inputContainer' => '{{content}}',
+            'multicheckboxContainer' => '<div class="form-group {{type}}{{required}}">{{content}}</div>',
+            'multicheckboxContainerError' => '<div class="form-group {{type}}{{required}} is-invalid">{{content}}</div>',
+            'multicheckboxLegend' => '<span class="sr-only">{{text}}</span>',
         ],
         'horizontal' => [
             'label' => '<label class="col-form-label %s"{{attrs}}>{{text}}{{tooltip}}</label>',
@@ -85,7 +94,10 @@ class FormHelper extends Helper
             'checkboxContainerError' => '<div class="form-group row {{type}}{{required}} is-invalid">{{content}}</div>',
             'radioContainer' => '<div class="form-group row {{type}}{{required}}">{{content}}</div>',
             'radioContainerError' => '<div class="form-group row {{type}}{{required}} is-invalid">{{content}}</div>',
-            'radioInlineWrapper' => '<div class="form-check form-check-inline">{{hidden}}{{input}}{{label}}</div>',
+            'radioInlineWrapper' => '<div class="form-check form-check-inline">{{hidden}}{{label}}</div>',
+            'multicheckboxContainer' => '<fieldset class="form-group {{type}}{{required}}"><div class="row">{{content}}</div></fieldset>',
+            'multicheckboxContainerError' => '<fieldset class="form-group {{type}}{{required}} is-invalid"><div class="row">{{content}}</div></fieldset>',
+            'multicheckboxLegend' => '<legend class="col-form-label pt-0 %s">{{text}}</legend>',
         ]
     ];
 
@@ -249,6 +261,12 @@ class FormHelper extends Helper
         ];
         $options = $this->_parseOptions($fieldName, $options);
 
+        if (!isset($options['nestedInput'])) {
+            $options['nestedInput'] = false;
+        }
+        $nestedInput = $options['nestedInput'];
+        unset($options['nestedInput']);
+
         $newTemplates = $options['templates'];
         if ($newTemplates) {
             $this->templater()->push();
@@ -304,6 +322,20 @@ class FormHelper extends Helper
 
                     if ($this->_align !== 'horizontal') {
                         $options['label'] = $this->injectClasses('form-check-label', (array)$options['label']);
+                    }
+                }
+
+                if ($options['type'] === 'multicheckbox') {
+                    $options['templates']['label'] = $this->templater()->get('multicheckboxLegend');
+
+                    if ($options['inline'] ||
+                        $this->_align === 'inline'
+                    ) {
+                        $options['templates']['checkboxWrapper'] = $this->templater()->get('checkboxInlineWrapper');
+                    }
+
+                    if ($nestedInput) {
+                        $options['templates']['nestingLabel'] = $this->templater()->get('nestingLabelNestedInput');
                     }
                 }
                 break;
@@ -421,9 +453,6 @@ class FormHelper extends Helper
             $attributes['label'] = [];
         }
         if ($attributes['label'] !== false) {
-            if (!isset($attributes['label']['input'])) {
-                $attributes['label']['input'] = false;
-            }
             $attributes['label'] = $this->injectClasses('form-check-label', $attributes['label']);
         }
 
@@ -623,6 +652,7 @@ class FormHelper extends Helper
         $offsetedGridClass = implode(' ', [$this->_gridClass('left', true), $this->_gridClass('middle')]);
 
         $templates['label'] = sprintf($templates['label'], $this->_gridClass('left'));
+        $templates['multicheckboxLegend'] = sprintf($templates['multicheckboxLegend'], $this->_gridClass('left'));
         $templates['formGroup'] = sprintf($templates['formGroup'], $this->_gridClass('middle'));
         foreach (['checkboxFormGroup', 'submitContainer'] as $value) {
             $templates[$value] = sprintf($templates[$value], $offsetedGridClass);

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -263,6 +263,9 @@ class FormHelper extends Helper
         ];
         $options = $this->_parseOptions($fieldName, $options);
 
+        $inline = $options['inline'];
+        unset($options['inline']);
+
         if (!isset($options['nestedInput'])) {
             $options['nestedInput'] = false;
         }
@@ -290,17 +293,16 @@ class FormHelper extends Helper
                     $options['templates']['label'] = $this->templater()->get('checkboxLabel');
                 }
 
-                if (!isset($options['inline'])) {
-                    $options['inline'] = $this->checkClasses($options['type'] . '-inline', (array)$options['label']);
+                if (!isset($inline)) {
+                    $inline = $this->checkClasses($options['type'] . '-inline', (array)$options['label']);
                 }
 
-                if ($options['inline']) {
+                if ($inline) {
                     $options['label'] = $this->injectClasses($options['type'] . '-inline', (array)$options['label']);
                     if (!isset($newTemplates['checkboxContainer'])) {
                         $options['templates']['checkboxContainer'] = '{{content}}';
                     }
                 }
-                unset($options['inline']);
                 break;
 
             case 'radio':
@@ -309,11 +311,11 @@ class FormHelper extends Helper
                     $options['label'] = $this->injectClasses('form-check-label', (array)$options['label']);
                 }
 
-                if ($options['inline'] && $this->_align === 'horizontal') {
+                if ($inline && $this->_align === 'horizontal') {
                     $options['templates']['radioWrapper'] = $this->templater()->get('radioInlineWrapper');
                 }
 
-                if ($options['inline'] && $this->_align !== 'horizontal') {
+                if ($inline && $this->_align !== 'horizontal') {
                     $options['templates']['formGroup'] = $this->templater()->get('radioInlineFormGroup');
                 }
                 break;
@@ -331,7 +333,7 @@ class FormHelper extends Helper
                     $options['templateVars']['groupId'] = $this->_domId($fieldName . '-group-label');
                     $options['templates']['label'] = $this->templater()->get('multicheckboxLabel');
 
-                    if ($options['inline'] ||
+                    if ($inline ||
                         $this->_align === 'inline'
                     ) {
                         $options['templates']['checkboxWrapper'] = $this->templater()->get('checkboxInlineWrapper');

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -1836,10 +1836,10 @@ class FormHelperTest extends TestCase
             ]
         ]);
         $expected = [
-            ['fieldset' => ['class' => 'form-group multicheckbox']],
-                ['legend' => true],
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['label' => ['id' => 'users-group-label', 'class' => 'd-block']],
                     'Users',
-                '/legend',
+                '/label',
                 ['input' => [
                     'type' => 'hidden',
                     'name' => 'users',
@@ -1869,7 +1869,7 @@ class FormHelperTest extends TestCase
                         'option 2',
                     '/label',
                 '/div',
-            '/fieldset',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -1887,10 +1887,10 @@ class FormHelperTest extends TestCase
             'nestedInput' => true
         ]);
         $expected = [
-            ['fieldset' => ['class' => 'form-group multicheckbox']],
-                ['legend' => true],
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['label' => ['id' => 'users-group-label', 'class' => 'd-block']],
                     'Users',
-                '/legend',
+                '/label',
                 ['input' => [
                     'type' => 'hidden',
                     'name' => 'users',
@@ -1920,7 +1920,110 @@ class FormHelperTest extends TestCase
                         'option 2',
                     '/label',
                 '/div',
-            '/fieldset',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignMultipleCheckboxControlInline()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2'
+            ],
+            'inline' => true
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['label' => ['id' => 'users-group-label', 'class' => 'd-block']],
+                    'Users',
+                '/label',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-1',
+                        'value' => 1
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-2',
+                        'value' => 2
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignMultipleCheckboxControlInlineNestedInput()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2'
+            ],
+            'inline' => true,
+            'nestedInput' => true
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['label' => ['id' => 'users-group-label', 'class' => 'd-block']],
+                    'Users',
+                '/label',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-1',
+                            'value' => 1
+                        ]],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-2',
+                            'value' => 2
+                        ]],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -1943,17 +2046,17 @@ class FormHelperTest extends TestCase
             ]
         ]);
         $expected = [
-            ['fieldset' => ['class' => 'form-group multicheckbox']],
-                ['legend' => true],
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['label' => ['id' => 'users-group-label', 'class' => 'd-block']],
                     'Users',
-                '/legend',
+                '/label',
                 ['input' => [
                     'type' => 'hidden',
                     'name' => 'users',
                     'value' => '',
                 ]],
-                ['fieldset' => true],
-                    ['legend' => true],
+                ['fieldset' => ['class' => 'form-group']],
+                    ['legend' => ['class' => 'col-form-label pt-0']],
                         'group 1',
                     '/legend',
                     ['div' => ['class' => 'form-check']],
@@ -1981,8 +2084,8 @@ class FormHelperTest extends TestCase
                         '/label',
                     '/div',
                  '/fieldset',
-                ['fieldset' => true],
-                    ['legend' => true],
+                ['fieldset' => ['class' => 'form-group']],
+                    ['legend' => ['class' => 'col-form-label pt-0']],
                         'group 2',
                     '/legend',
                     ['div' => ['class' => 'form-check']],
@@ -2010,7 +2113,7 @@ class FormHelperTest extends TestCase
                         '/label',
                     '/div',
                  '/fieldset',
-            '/fieldset',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -2034,17 +2137,17 @@ class FormHelperTest extends TestCase
             'nestedInput' => true
         ]);
         $expected = [
-            ['fieldset' => ['class' => 'form-group multicheckbox']],
-                ['legend' => true],
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['label' => ['id' => 'users-group-label', 'class' => 'd-block']],
                     'Users',
-                '/legend',
+                '/label',
                 ['input' => [
                     'type' => 'hidden',
                     'name' => 'users',
                     'value' => '',
                 ]],
-                ['fieldset' => true],
-                    ['legend' => true],
+                ['fieldset' => ['class' => 'form-group']],
+                    ['legend' => ['class' => 'col-form-label pt-0']],
                         'group 1',
                     '/legend',
                     ['div' => ['class' => 'form-check']],
@@ -2072,8 +2175,8 @@ class FormHelperTest extends TestCase
                         '/label',
                     '/div',
                  '/fieldset',
-                ['fieldset' => true],
-                    ['legend' => true],
+                ['fieldset' => ['class' => 'form-group']],
+                    ['legend' => ['class' => 'col-form-label pt-0']],
                         'group 2',
                     '/legend',
                     ['div' => ['class' => 'form-check']],
@@ -2101,7 +2204,190 @@ class FormHelperTest extends TestCase
                         '/label',
                     '/div',
                  '/fieldset',
-            '/fieldset',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignMultipleCheckboxControlOptionGroupsInline()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                'group 1' => [
+                    1 => 'option 1',
+                    2 => 'option 2'
+                ],
+                'group 2' => [
+                    3 => 'option 3',
+                    4 => 'option 4'
+                ],
+            ],
+            'inline' => true
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['label' => ['id' => 'users-group-label', 'class' => 'd-block']],
+                    'Users',
+                '/label',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['fieldset' => ['class' => 'form-group']],
+                    ['legend' => ['class' => 'col-form-label pt-0']],
+                        'group 1',
+                    '/legend',
+                    ['div' => ['class' => 'form-check form-check-inline']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-1',
+                            'value' => 1
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                            'option 1',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'form-check form-check-inline']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-2',
+                            'value' => 2
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                            'option 2',
+                        '/label',
+                    '/div',
+                 '/fieldset',
+                ['fieldset' => ['class' => 'form-group']],
+                    ['legend' => ['class' => 'col-form-label pt-0']],
+                        'group 2',
+                    '/legend',
+                    ['div' => ['class' => 'form-check form-check-inline']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-3',
+                            'value' => 3
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-3']],
+                            'option 3',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'form-check form-check-inline']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-4',
+                            'value' => 4
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-4']],
+                            'option 4',
+                        '/label',
+                    '/div',
+                 '/fieldset',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignMultipleCheckboxControlOptionGroupsInlineNestedInput()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                'group 1' => [
+                    1 => 'option 1',
+                    2 => 'option 2'
+                ],
+                'group 2' => [
+                    3 => 'option 3',
+                    4 => 'option 4'
+                ],
+            ],
+            'inline' => true,
+            'nestedInput' => true
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['label' => ['id' => 'users-group-label', 'class' => 'd-block']],
+                    'Users',
+                '/label',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['fieldset' => ['class' => 'form-group']],
+                    ['legend' => ['class' => 'col-form-label pt-0']],
+                        'group 1',
+                    '/legend',
+                    ['div' => ['class' => 'form-check form-check-inline']],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                            ['input' => [
+                                'class' => 'form-check-input',
+                                'type' => 'checkbox',
+                                'name' => 'users[]',
+                                'id' => 'users-1',
+                                'value' => 1
+                            ]],
+                            'option 1',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'form-check form-check-inline']],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                            ['input' => [
+                                'class' => 'form-check-input',
+                                'type' => 'checkbox',
+                                'name' => 'users[]',
+                                'id' => 'users-2',
+                                'value' => 2
+                            ]],
+                            'option 2',
+                        '/label',
+                    '/div',
+                 '/fieldset',
+                ['fieldset' => ['class' => 'form-group']],
+                    ['legend' => ['class' => 'col-form-label pt-0']],
+                        'group 2',
+                    '/legend',
+                    ['div' => ['class' => 'form-check form-check-inline']],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-3']],
+                            ['input' => [
+                                'class' => 'form-check-input',
+                                'type' => 'checkbox',
+                                'name' => 'users[]',
+                                'id' => 'users-3',
+                                'value' => 3
+                            ]],
+                            'option 3',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'form-check form-check-inline']],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-4']],
+                            ['input' => [
+                                'class' => 'form-check-input',
+                                'type' => 'checkbox',
+                                'name' => 'users[]',
+                                'id' => 'users-4',
+                                'value' => 4
+                            ]],
+                            'option 4',
+                        '/label',
+                    '/div',
+                 '/fieldset',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -2122,10 +2408,10 @@ class FormHelperTest extends TestCase
             ]
         ]);
         $expected = [
-            ['fieldset' => ['class' => 'form-group multicheckbox']],
-                ['legend' => true],
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['label' => ['id' => 'users-group-label', 'class' => 'd-block']],
                     'Users',
-                '/legend',
+                '/label',
                 ['input' => [
                     'type' => 'hidden',
                     'name' => 'users',
@@ -2155,8 +2441,8 @@ class FormHelperTest extends TestCase
                         'option 2',
                     '/label',
                 '/div',
-                ['fieldset' => true],
-                    ['legend' => true],
+                ['fieldset' => ['class' => 'form-group']],
+                    ['legend' => ['class' => 'col-form-label pt-0']],
                         'group',
                     '/legend',
                     ['div' => ['class' => 'form-check']],
@@ -2184,7 +2470,7 @@ class FormHelperTest extends TestCase
                         '/label',
                     '/div',
                  '/fieldset',
-            '/fieldset',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -2229,10 +2515,10 @@ class FormHelperTest extends TestCase
             ],
         ]);
         $expected = [
-            ['fieldset' => ['class' => 'form-group multicheckbox']],
-                ['legend' => true],
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['label' => ['id' => 'users-group-label', 'class' => 'd-block']],
                     'Users',
-                '/legend',
+                '/label',
                 ['input' => [
                     'type' => 'hidden',
                     'name' => 'users',
@@ -2274,8 +2560,8 @@ class FormHelperTest extends TestCase
                         'option 3',
                     '/label',
                 '/div',
-                ['fieldset' => true],
-                    ['legend' => true],
+                ['fieldset' => ['class' => 'form-group']],
+                    ['legend' => ['class' => 'col-form-label pt-0']],
                         'group',
                     '/legend',
                     ['div' => ['class' => 'form-check']],
@@ -2324,7 +2610,7 @@ class FormHelperTest extends TestCase
                         '/label',
                     '/div',
                  '/fieldset',
-            '/fieldset',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -2346,10 +2632,10 @@ class FormHelperTest extends TestCase
             'nestedInput' => true
         ]);
         $expected = [
-            ['fieldset' => ['class' => 'form-group multicheckbox']],
-                ['legend' => true],
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['label' => ['id' => 'users-group-label', 'class' => 'd-block']],
                     'Users',
-                '/legend',
+                '/label',
                 ['input' => [
                     'type' => 'hidden',
                     'name' => 'users',
@@ -2379,8 +2665,8 @@ class FormHelperTest extends TestCase
                         'option 2',
                     '/label',
                 '/div',
-                ['fieldset' => true],
-                    ['legend' => true],
+                ['fieldset' => ['class' => 'form-group']],
+                    ['legend' => ['class' => 'col-form-label pt-0']],
                         'group',
                     '/legend',
                     ['div' => ['class' => 'form-check']],
@@ -2408,7 +2694,7 @@ class FormHelperTest extends TestCase
                         '/label',
                     '/div',
                  '/fieldset',
-            '/fieldset',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -2454,10 +2740,10 @@ class FormHelperTest extends TestCase
             'nestedInput' => true
         ]);
         $expected = [
-            ['fieldset' => ['class' => 'form-group multicheckbox']],
-                ['legend' => true],
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['label' => ['id' => 'users-group-label', 'class' => 'd-block']],
                     'Users',
-                '/legend',
+                '/label',
                 ['input' => [
                     'type' => 'hidden',
                     'name' => 'users',
@@ -2499,8 +2785,8 @@ class FormHelperTest extends TestCase
                         'option 3',
                     '/label',
                 '/div',
-                ['fieldset' => true],
-                    ['legend' => true],
+                ['fieldset' => ['class' => 'form-group']],
+                    ['legend' => ['class' => 'col-form-label pt-0']],
                         'group',
                     '/legend',
                     ['div' => ['class' => 'form-check']],
@@ -2549,7 +2835,7 @@ class FormHelperTest extends TestCase
                         '/label',
                     '/div',
                  '/fieldset',
-            '/fieldset',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -2573,11 +2859,11 @@ class FormHelperTest extends TestCase
             ]
         ]);
         $expected = [
-            ['fieldset' => ['class' => 'form-group multicheckbox']],
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
                 ['div' => ['class' => 'row']],
-                    ['legend' => ['class' => 'col-form-label pt-0 col-sm-5']],
+                    ['label' => ['id' => 'users-group-label', 'class' => 'col-form-label d-block pt-0 col-sm-5']],
                         'Users',
-                    '/legend',
+                    '/label',
                     ['div' => ['class' => 'col-sm-7']],
                         ['input' => [
                             'type' => 'hidden',
@@ -2610,7 +2896,7 @@ class FormHelperTest extends TestCase
                         '/div',
                     '/div',
                 '/div',
-            '/fieldset',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -2635,11 +2921,11 @@ class FormHelperTest extends TestCase
             'nestedInput' => true
         ]);
         $expected = [
-            ['fieldset' => ['class' => 'form-group multicheckbox']],
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
                 ['div' => ['class' => 'row']],
-                    ['legend' => ['class' => 'col-form-label pt-0 col-sm-5']],
+                    ['label' => ['id' => 'users-group-label', 'class' => 'col-form-label d-block pt-0 col-sm-5']],
                         'Users',
-                    '/legend',
+                    '/label',
                     ['div' => ['class' => 'col-sm-7']],
                         ['input' => [
                             'type' => 'hidden',
@@ -2672,7 +2958,132 @@ class FormHelperTest extends TestCase
                         '/div',
                     '/div',
                 '/div',
-            '/fieldset',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignMultipleCheckboxControlInline()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7
+                ]
+            ]
+        ]);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2'
+            ],
+            'inline' => true
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['div' => ['class' => 'row']],
+                    ['label' => ['id' => 'users-group-label', 'class' => 'col-form-label d-block pt-0 col-sm-5']],
+                        'Users',
+                    '/label',
+                    ['div' => ['class' => 'col-sm-7']],
+                        ['input' => [
+                            'type' => 'hidden',
+                            'name' => 'users',
+                            'value' => '',
+                        ]],
+                        ['div' => ['class' => 'form-check form-check-inline']],
+                            ['input' => [
+                                'class' => 'form-check-input',
+                                'type' => 'checkbox',
+                                'name' => 'users[]',
+                                'id' => 'users-1',
+                                'value' => 1
+                            ]],
+                            ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                                'option 1',
+                            '/label',
+                        '/div',
+                        ['div' => ['class' => 'form-check form-check-inline']],
+                            ['input' => [
+                                'class' => 'form-check-input',
+                                'type' => 'checkbox',
+                                'name' => 'users[]',
+                                'id' => 'users-2',
+                                'value' => 2
+                            ]],
+                            ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                                'option 2',
+                            '/label',
+                        '/div',
+                    '/div',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignMultipleCheckboxControlInlineNestedInput()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7
+                ]
+            ]
+        ]);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2'
+            ],
+            'inline' => true,
+            'nestedInput' => true
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['div' => ['class' => 'row']],
+                    ['label' => ['id' => 'users-group-label', 'class' => 'col-form-label d-block pt-0 col-sm-5']],
+                        'Users',
+                    '/label',
+                    ['div' => ['class' => 'col-sm-7']],
+                        ['input' => [
+                            'type' => 'hidden',
+                            'name' => 'users',
+                            'value' => '',
+                        ]],
+                        ['div' => ['class' => 'form-check form-check-inline']],
+                            ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                                ['input' => [
+                                    'class' => 'form-check-input',
+                                    'type' => 'checkbox',
+                                    'name' => 'users[]',
+                                    'id' => 'users-1',
+                                    'value' => 1
+                                ]],
+                                'option 1',
+                            '/label',
+                        '/div',
+                        ['div' => ['class' => 'form-check form-check-inline']],
+                            ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                                ['input' => [
+                                    'class' => 'form-check-input',
+                                    'type' => 'checkbox',
+                                    'name' => 'users[]',
+                                    'id' => 'users-2',
+                                    'value' => 2
+                                ]],
+                                'option 2',
+                            '/label',
+                        '/div',
+                    '/div',
+                '/div',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -2702,19 +3113,19 @@ class FormHelperTest extends TestCase
             ]
         ]);
         $expected = [
-            ['fieldset' => ['class' => 'form-group multicheckbox']],
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
                 ['div' => ['class' => 'row']],
-                    ['legend' => ['class' => 'col-form-label pt-0 col-sm-5']],
+                    ['label' => ['id' => 'users-group-label', 'class' => 'col-form-label d-block pt-0 col-sm-5']],
                         'Users',
-                    '/legend',
+                    '/label',
                     ['div' => ['class' => 'col-sm-7']],
                         ['input' => [
                             'type' => 'hidden',
                             'name' => 'users',
                             'value' => '',
                         ]],
-                        ['fieldset' => true],
-                            ['legend' => true],
+                        ['fieldset' => ['class' => 'form-group']],
+                            ['legend' => ['class' => 'col-form-label pt-0']],
                                 'group 1',
                             '/legend',
                             ['div' => ['class' => 'form-check']],
@@ -2742,8 +3153,8 @@ class FormHelperTest extends TestCase
                                 '/label',
                             '/div',
                          '/fieldset',
-                        ['fieldset' => true],
-                            ['legend' => true],
+                        ['fieldset' => ['class' => 'form-group']],
+                            ['legend' => ['class' => 'col-form-label pt-0']],
                                 'group 2',
                             '/legend',
                             ['div' => ['class' => 'form-check']],
@@ -2773,7 +3184,7 @@ class FormHelperTest extends TestCase
                          '/fieldset',
                     '/div',
                 '/div',
-            '/fieldset',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -2804,19 +3215,19 @@ class FormHelperTest extends TestCase
             'nestedInput' => true
         ]);
         $expected = [
-            ['fieldset' => ['class' => 'form-group multicheckbox']],
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
                 ['div' => ['class' => 'row']],
-                    ['legend' => ['class' => 'col-form-label pt-0 col-sm-5']],
+                    ['label' => ['id' => 'users-group-label', 'class' => 'col-form-label d-block pt-0 col-sm-5']],
                         'Users',
-                    '/legend',
+                    '/label',
                     ['div' => ['class' => 'col-sm-7']],
                         ['input' => [
                             'type' => 'hidden',
                             'name' => 'users',
                             'value' => '',
                         ]],
-                        ['fieldset' => true],
-                            ['legend' => true],
+                        ['fieldset' => ['class' => 'form-group']],
+                            ['legend' => ['class' => 'col-form-label pt-0']],
                                 'group 1',
                             '/legend',
                             ['div' => ['class' => 'form-check']],
@@ -2844,8 +3255,8 @@ class FormHelperTest extends TestCase
                                 '/label',
                             '/div',
                          '/fieldset',
-                        ['fieldset' => true],
-                            ['legend' => true],
+                        ['fieldset' => ['class' => 'form-group']],
+                            ['legend' => ['class' => 'col-form-label pt-0']],
                                 'group 2',
                             '/legend',
                             ['div' => ['class' => 'form-check']],
@@ -2875,7 +3286,212 @@ class FormHelperTest extends TestCase
                          '/fieldset',
                     '/div',
                 '/div',
-            '/fieldset',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignMultipleCheckboxControlOptionGroupsInline()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7
+                ]
+            ]
+        ]);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                'group 1' => [
+                    1 => 'option 1',
+                    2 => 'option 2'
+                ],
+                'group 2' => [
+                    3 => 'option 3',
+                    4 => 'option 4'
+                ],
+            ],
+            'inline' => true
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['div' => ['class' => 'row']],
+                    ['label' => ['id' => 'users-group-label', 'class' => 'col-form-label d-block pt-0 col-sm-5']],
+                        'Users',
+                    '/label',
+                    ['div' => ['class' => 'col-sm-7']],
+                        ['input' => [
+                            'type' => 'hidden',
+                            'name' => 'users',
+                            'value' => '',
+                        ]],
+                        ['fieldset' => ['class' => 'form-group']],
+                            ['legend' => ['class' => 'col-form-label pt-0']],
+                                'group 1',
+                            '/legend',
+                            ['div' => ['class' => 'form-check form-check-inline']],
+                                ['input' => [
+                                    'class' => 'form-check-input',
+                                    'type' => 'checkbox',
+                                    'name' => 'users[]',
+                                    'id' => 'users-1',
+                                    'value' => 1
+                                ]],
+                                ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                                    'option 1',
+                                '/label',
+                            '/div',
+                            ['div' => ['class' => 'form-check form-check-inline']],
+                                ['input' => [
+                                    'class' => 'form-check-input',
+                                    'type' => 'checkbox',
+                                    'name' => 'users[]',
+                                    'id' => 'users-2',
+                                    'value' => 2
+                                ]],
+                                ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                                    'option 2',
+                                '/label',
+                            '/div',
+                         '/fieldset',
+                        ['fieldset' => ['class' => 'form-group']],
+                            ['legend' => ['class' => 'col-form-label pt-0']],
+                                'group 2',
+                            '/legend',
+                            ['div' => ['class' => 'form-check form-check-inline']],
+                                ['input' => [
+                                    'class' => 'form-check-input',
+                                    'type' => 'checkbox',
+                                    'name' => 'users[]',
+                                    'id' => 'users-3',
+                                    'value' => 3
+                                ]],
+                                ['label' => ['class' => 'form-check-label', 'for' => 'users-3']],
+                                    'option 3',
+                                '/label',
+                            '/div',
+                            ['div' => ['class' => 'form-check form-check-inline']],
+                                ['input' => [
+                                    'class' => 'form-check-input',
+                                    'type' => 'checkbox',
+                                    'name' => 'users[]',
+                                    'id' => 'users-4',
+                                    'value' => 4
+                                ]],
+                                ['label' => ['class' => 'form-check-label', 'for' => 'users-4']],
+                                    'option 4',
+                                '/label',
+                            '/div',
+                         '/fieldset',
+                    '/div',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignMultipleCheckboxControlOptionGroupsInlineNestedInput()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7
+                ]
+            ]
+        ]);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                'group 1' => [
+                    1 => 'option 1',
+                    2 => 'option 2'
+                ],
+                'group 2' => [
+                    3 => 'option 3',
+                    4 => 'option 4'
+                ],
+            ],
+            'inline' => true,
+            'nestedInput' => true
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['div' => ['class' => 'row']],
+                    ['label' => ['id' => 'users-group-label', 'class' => 'col-form-label d-block pt-0 col-sm-5']],
+                        'Users',
+                    '/label',
+                    ['div' => ['class' => 'col-sm-7']],
+                        ['input' => [
+                            'type' => 'hidden',
+                            'name' => 'users',
+                            'value' => '',
+                        ]],
+                        ['fieldset' => ['class' => 'form-group']],
+                            ['legend' => ['class' => 'col-form-label pt-0']],
+                                'group 1',
+                            '/legend',
+                            ['div' => ['class' => 'form-check form-check-inline']],
+                                ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                                    ['input' => [
+                                        'class' => 'form-check-input',
+                                        'type' => 'checkbox',
+                                        'name' => 'users[]',
+                                        'id' => 'users-1',
+                                        'value' => 1
+                                    ]],
+                                    'option 1',
+                                '/label',
+                            '/div',
+                            ['div' => ['class' => 'form-check form-check-inline']],
+                                ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                                    ['input' => [
+                                        'class' => 'form-check-input',
+                                        'type' => 'checkbox',
+                                        'name' => 'users[]',
+                                        'id' => 'users-2',
+                                        'value' => 2
+                                    ]],
+                                    'option 2',
+                                '/label',
+                            '/div',
+                         '/fieldset',
+                        ['fieldset' => ['class' => 'form-group']],
+                            ['legend' => ['class' => 'col-form-label pt-0']],
+                                'group 2',
+                            '/legend',
+                            ['div' => ['class' => 'form-check form-check-inline']],
+                                ['label' => ['class' => 'form-check-label', 'for' => 'users-3']],
+                                    ['input' => [
+                                        'class' => 'form-check-input',
+                                        'type' => 'checkbox',
+                                        'name' => 'users[]',
+                                        'id' => 'users-3',
+                                        'value' => 3
+                                    ]],
+                                    'option 3',
+                                '/label',
+                            '/div',
+                            ['div' => ['class' => 'form-check form-check-inline']],
+                                ['label' => ['class' => 'form-check-label', 'for' => 'users-4']],
+                                    ['input' => [
+                                        'class' => 'form-check-input',
+                                        'type' => 'checkbox',
+                                        'name' => 'users[]',
+                                        'id' => 'users-4',
+                                        'value' => 4
+                                    ]],
+                                    'option 4',
+                                '/label',
+                            '/div',
+                         '/fieldset',
+                    '/div',
+                '/div',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -2903,11 +3519,11 @@ class FormHelperTest extends TestCase
             ]
         ]);
         $expected = [
-            ['fieldset' => ['class' => 'form-group multicheckbox']],
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
                 ['div' => ['class' => 'row']],
-                    ['legend' => ['class' => 'col-form-label pt-0 col-sm-5']],
+                    ['label' => ['id' => 'users-group-label', 'class' => 'col-form-label d-block pt-0 col-sm-5']],
                         'Users',
-                    '/legend',
+                    '/label',
                     ['div' => ['class' => 'col-sm-7']],
                         ['input' => [
                             'type' => 'hidden',
@@ -2938,8 +3554,8 @@ class FormHelperTest extends TestCase
                                 'option 2',
                             '/label',
                         '/div',
-                        ['fieldset' => true],
-                            ['legend' => true],
+                        ['fieldset' => ['class' => 'form-group']],
+                            ['legend' => ['class' => 'col-form-label pt-0']],
                                 'group',
                             '/legend',
                             ['div' => ['class' => 'form-check']],
@@ -2969,7 +3585,7 @@ class FormHelperTest extends TestCase
                          '/fieldset',
                     '/div',
                 '/div',
-            '/fieldset',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -3021,11 +3637,11 @@ class FormHelperTest extends TestCase
             ],
         ]);
         $expected = [
-            ['fieldset' => ['class' => 'form-group multicheckbox']],
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
                 ['div' => ['class' => 'row']],
-                    ['legend' => ['class' => 'col-form-label pt-0 col-sm-5']],
+                    ['label' => ['id' => 'users-group-label', 'class' => 'col-form-label d-block pt-0 col-sm-5']],
                         'Users',
-                    '/legend',
+                    '/label',
                     ['div' => ['class' => 'col-sm-7']],
                         ['input' => [
                             'type' => 'hidden',
@@ -3068,8 +3684,8 @@ class FormHelperTest extends TestCase
                                 'option 3',
                             '/label',
                         '/div',
-                        ['fieldset' => true],
-                            ['legend' => true],
+                        ['fieldset' => ['class' => 'form-group']],
+                            ['legend' => ['class' => 'col-form-label pt-0']],
                                 'group',
                             '/legend',
                             ['div' => ['class' => 'form-check']],
@@ -3120,7 +3736,7 @@ class FormHelperTest extends TestCase
                          '/fieldset',
                     '/div',
                 '/div',
-            '/fieldset',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -3149,11 +3765,11 @@ class FormHelperTest extends TestCase
             'nestedInput' => true
         ]);
         $expected = [
-            ['fieldset' => ['class' => 'form-group multicheckbox']],
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
                 ['div' => ['class' => 'row']],
-                    ['legend' => ['class' => 'col-form-label pt-0 col-sm-5']],
+                    ['label' => ['id' => 'users-group-label', 'class' => 'col-form-label d-block pt-0 col-sm-5']],
                         'Users',
-                    '/legend',
+                    '/label',
                     ['div' => ['class' => 'col-sm-7']],
                         ['input' => [
                             'type' => 'hidden',
@@ -3184,8 +3800,8 @@ class FormHelperTest extends TestCase
                                 'option 2',
                             '/label',
                         '/div',
-                        ['fieldset' => true],
-                            ['legend' => true],
+                        ['fieldset' => ['class' => 'form-group']],
+                            ['legend' => ['class' => 'col-form-label pt-0']],
                                 'group',
                             '/legend',
                             ['div' => ['class' => 'form-check']],
@@ -3215,7 +3831,7 @@ class FormHelperTest extends TestCase
                          '/fieldset',
                     '/div',
                 '/div',
-            '/fieldset',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -3268,11 +3884,11 @@ class FormHelperTest extends TestCase
             'nestedInput' => true
         ]);
         $expected = [
-            ['fieldset' => ['class' => 'form-group multicheckbox']],
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
                 ['div' => ['class' => 'row']],
-                    ['legend' => ['class' => 'col-form-label pt-0 col-sm-5']],
+                    ['label' => ['id' => 'users-group-label', 'class' => 'col-form-label d-block pt-0 col-sm-5']],
                         'Users',
-                    '/legend',
+                    '/label',
                     ['div' => ['class' => 'col-sm-7']],
                         ['input' => [
                             'type' => 'hidden',
@@ -3315,8 +3931,8 @@ class FormHelperTest extends TestCase
                                 'option 3',
                             '/label',
                         '/div',
-                        ['fieldset' => true],
-                            ['legend' => true],
+                        ['fieldset' => ['class' => 'form-group']],
+                            ['legend' => ['class' => 'col-form-label pt-0']],
                                 'group',
                             '/legend',
                             ['div' => ['class' => 'form-check']],
@@ -3367,7 +3983,7 @@ class FormHelperTest extends TestCase
                          '/fieldset',
                     '/div',
                 '/div',
-            '/fieldset',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -3388,8 +4004,8 @@ class FormHelperTest extends TestCase
             ]
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group multicheckbox']],
-                ['span' => ['class' => 'sr-only']],
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['span' => ['id' => 'users-group-label', 'class' => 'sr-only']],
                     'Users',
                 '/span',
                 ['input' => [
@@ -3450,8 +4066,8 @@ class FormHelperTest extends TestCase
             ],
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group multicheckbox']],
-                ['span' => ['class' => 'sr-only']],
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['span' => ['id' => 'users-group-label', 'class' => 'sr-only']],
                     'Users',
                 '/span',
                 ['input' => [
@@ -3517,8 +4133,8 @@ class FormHelperTest extends TestCase
             'nestedInput' => true
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group multicheckbox']],
-                ['span' => ['class' => 'sr-only']],
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['span' => ['id' => 'users-group-label', 'class' => 'sr-only']],
                     'Users',
                 '/span',
                 ['input' => [
@@ -3580,8 +4196,8 @@ class FormHelperTest extends TestCase
             'nestedInput' => true
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group multicheckbox']],
-                ['span' => ['class' => 'sr-only']],
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['span' => ['id' => 'users-group-label', 'class' => 'sr-only']],
                     'Users',
                 '/span',
                 ['input' => [

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -1502,65 +1502,6 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testMultipleCheckboxControl method
-     *
-     * @return void
-     */
-    public function testMultipleCheckboxControl()
-    {
-        $this->Form->create($this->article);
-
-        $result = $this->Form->control('users', [
-            'multiple' => 'checkbox',
-            'options' => [
-                1 => 'User 1',
-                2 => 'User 2'
-            ]
-        ]);
-        $expected = [
-            ['div' => ['class' => 'form-group multicheckbox']],
-            ['label' => ['class' => 'form-check-label']],
-            'Users',
-            '/label',
-            'input' => [
-                'type' => 'hidden',
-                'name' => 'users',
-                'value' => '',
-            ],
-            ['div' => ['class' => 'form-check']],
-            [
-                'input' => [
-                    'type' => 'checkbox',
-                    'name' => 'users[]',
-                    'id' => 'users-1',
-                    'value' => 1,
-                    'class' => 'form-check-input',
-                ]
-            ],
-            ['label' => ['for' => 'users-1', 'class' => 'form-check-label']],
-            'User 1',
-            '/label',
-            '/div',
-            ['div' => ['class' => 'form-check']],
-            [
-                'input' => [
-                    'type' => 'checkbox',
-                    'name' => 'users[]',
-                    'id' => 'users-2',
-                    'value' => 2,
-                    'class' => 'form-check-input',
-                ]
-            ],
-            ['label' => ['for' => 'users-2', 'class' => 'form-check-label']],
-            'User 2',
-            '/label',
-            '/div',
-            '/div'
-        ];
-        $this->assertHtml($expected, $result);
-    }
-
-    /**
      * testHelpText method
      *
      * @return void
@@ -1883,11 +1824,1809 @@ class FormHelperTest extends TestCase
         $this->Form->create($this->article, ['align' => 'foo']);
     }
 
-/*    public function testConstruct()
+    public function testDefaultAlignMultipleCheckboxControl()
     {
         $this->Form->create($this->article);
-        $this->_defaultConfig['templateSet'] = ['test'];
 
-        debug($this->Form);
-    }*/
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2'
+            ]
+        ]);
+        $expected = [
+            ['fieldset' => ['class' => 'form-group multicheckbox']],
+                ['legend' => true],
+                    'Users',
+                '/legend',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'form-check']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-1',
+                        'value' => 1
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-2',
+                        'value' => 2
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/fieldset',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignMultipleCheckboxControlNestedInput()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2'
+            ],
+            'nestedInput' => true
+        ]);
+        $expected = [
+            ['fieldset' => ['class' => 'form-group multicheckbox']],
+                ['legend' => true],
+                    'Users',
+                '/legend',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'form-check']],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-1',
+                            'value' => 1
+                        ]],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check']],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-2',
+                            'value' => 2
+                        ]],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/fieldset',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignMultipleCheckboxControlOptionGroups()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                'group 1' => [
+                    1 => 'option 1',
+                    2 => 'option 2'
+                ],
+                'group 2' => [
+                    3 => 'option 3',
+                    4 => 'option 4'
+                ],
+            ]
+        ]);
+        $expected = [
+            ['fieldset' => ['class' => 'form-group multicheckbox']],
+                ['legend' => true],
+                    'Users',
+                '/legend',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['fieldset' => true],
+                    ['legend' => true],
+                        'group 1',
+                    '/legend',
+                    ['div' => ['class' => 'form-check']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-1',
+                            'value' => 1
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                            'option 1',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'form-check']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-2',
+                            'value' => 2
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                            'option 2',
+                        '/label',
+                    '/div',
+                 '/fieldset',
+                ['fieldset' => true],
+                    ['legend' => true],
+                        'group 2',
+                    '/legend',
+                    ['div' => ['class' => 'form-check']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-3',
+                            'value' => 3
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-3']],
+                            'option 3',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'form-check']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-4',
+                            'value' => 4
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-4']],
+                            'option 4',
+                        '/label',
+                    '/div',
+                 '/fieldset',
+            '/fieldset',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignMultipleCheckboxControlOptionGroupsNestedInput()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                'group 1' => [
+                    1 => 'option 1',
+                    2 => 'option 2'
+                ],
+                'group 2' => [
+                    3 => 'option 3',
+                    4 => 'option 4'
+                ],
+            ],
+            'nestedInput' => true
+        ]);
+        $expected = [
+            ['fieldset' => ['class' => 'form-group multicheckbox']],
+                ['legend' => true],
+                    'Users',
+                '/legend',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['fieldset' => true],
+                    ['legend' => true],
+                        'group 1',
+                    '/legend',
+                    ['div' => ['class' => 'form-check']],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                            ['input' => [
+                                'class' => 'form-check-input',
+                                'type' => 'checkbox',
+                                'name' => 'users[]',
+                                'id' => 'users-1',
+                                'value' => 1
+                            ]],
+                            'option 1',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'form-check']],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                            ['input' => [
+                                'class' => 'form-check-input',
+                                'type' => 'checkbox',
+                                'name' => 'users[]',
+                                'id' => 'users-2',
+                                'value' => 2
+                            ]],
+                            'option 2',
+                        '/label',
+                    '/div',
+                 '/fieldset',
+                ['fieldset' => true],
+                    ['legend' => true],
+                        'group 2',
+                    '/legend',
+                    ['div' => ['class' => 'form-check']],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-3']],
+                            ['input' => [
+                                'class' => 'form-check-input',
+                                'type' => 'checkbox',
+                                'name' => 'users[]',
+                                'id' => 'users-3',
+                                'value' => 3
+                            ]],
+                            'option 3',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'form-check']],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-4']],
+                            ['input' => [
+                                'class' => 'form-check-input',
+                                'type' => 'checkbox',
+                                'name' => 'users[]',
+                                'id' => 'users-4',
+                                'value' => 4
+                            ]],
+                            'option 4',
+                        '/label',
+                    '/div',
+                 '/fieldset',
+            '/fieldset',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignMultipleCheckboxControlOptionsGroupsAndSingleEntries()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+                'group' => [
+                    3 => 'option 3',
+                    4 => 'option 4',
+                ]
+            ]
+        ]);
+        $expected = [
+            ['fieldset' => ['class' => 'form-group multicheckbox']],
+                ['legend' => true],
+                    'Users',
+                '/legend',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'form-check']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-1',
+                        'value' => 1
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-2',
+                        'value' => 2
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+                ['fieldset' => true],
+                    ['legend' => true],
+                        'group',
+                    '/legend',
+                    ['div' => ['class' => 'form-check']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-3',
+                            'value' => 3
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-3']],
+                            'option 3',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'form-check']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-4',
+                            'value' => 4
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-4']],
+                            'option 4',
+                        '/label',
+                    '/div',
+                 '/fieldset',
+            '/fieldset',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignMultipleCheckboxControlOptionsGroupsAndSingleEntriesWithPerOptionConfiguration()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+                4 => [
+                    'text' => 'option 3',
+                    'value' => 12,
+                    'class' => 'custominputclass',
+                    'label' => [
+                        'class' => 'customlabelclass'
+                    ]
+                ],
+                'group' => [
+                    10 => 'option 4',
+                    20 => [
+                        'text' => 'option 4',
+                        'value' => 20,
+                        'class' => 'custominputclass'
+                    ],
+                    30 => [
+                        'text' => 'option 5 without label',
+                        'value' => 30,
+                        'label' => false
+                    ],
+                    40 => [
+                        'text' => 'option 6',
+                        'value' => 40,
+                        'label' => [
+                            'class' => 'customlabelclass'
+                        ]
+                    ],
+                ]
+            ],
+        ]);
+        $expected = [
+            ['fieldset' => ['class' => 'form-group multicheckbox']],
+                ['legend' => true],
+                    'Users',
+                '/legend',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'form-check']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-1',
+                        'value' => 1
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-2',
+                        'value' => 2
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check']],
+                    ['input' => [
+                        'class' => 'custominputclass',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-12',
+                        'value' => 12
+                    ]],
+                    ['label' => ['class' => 'customlabelclass', 'for' => 'users-12']],
+                        'option 3',
+                    '/label',
+                '/div',
+                ['fieldset' => true],
+                    ['legend' => true],
+                        'group',
+                    '/legend',
+                    ['div' => ['class' => 'form-check']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-10',
+                            'value' => 10
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-10']],
+                            'option 4',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'form-check']],
+                        ['input' => [
+                            'class' => 'custominputclass',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-20',
+                            'value' => 20
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-20']],
+                            'option 4',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'form-check']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-30',
+                            'value' => 30
+                        ]],
+                    '/div',
+                    ['div' => ['class' => 'form-check']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-40',
+                            'value' => 40
+                        ]],
+                        ['label' => ['class' => 'customlabelclass', 'for' => 'users-40']],
+                            'option 6',
+                        '/label',
+                    '/div',
+                 '/fieldset',
+            '/fieldset',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignMultipleCheckboxControlOptionsGroupsAndSingleEntriesNestedInput()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+                'group' => [
+                    3 => 'option 3',
+                    4 => 'option 4',
+                ]
+            ],
+            'nestedInput' => true
+        ]);
+        $expected = [
+            ['fieldset' => ['class' => 'form-group multicheckbox']],
+                ['legend' => true],
+                    'Users',
+                '/legend',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'form-check']],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-1',
+                            'value' => 1
+                        ]],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check']],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-2',
+                            'value' => 2
+                        ]],
+                        'option 2',
+                    '/label',
+                '/div',
+                ['fieldset' => true],
+                    ['legend' => true],
+                        'group',
+                    '/legend',
+                    ['div' => ['class' => 'form-check']],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-3']],
+                            ['input' => [
+                                'class' => 'form-check-input',
+                                'type' => 'checkbox',
+                                'name' => 'users[]',
+                                'id' => 'users-3',
+                                'value' => 3
+                            ]],
+                            'option 3',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'form-check']],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-4']],
+                            ['input' => [
+                                'class' => 'form-check-input',
+                                'type' => 'checkbox',
+                                'name' => 'users[]',
+                                'id' => 'users-4',
+                                'value' => 4
+                            ]],
+                            'option 4',
+                        '/label',
+                    '/div',
+                 '/fieldset',
+            '/fieldset',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignMultipleCheckboxControlOptionsGroupsAndSingleEntriesWithPerOptionConfigurationNestedInput()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+                4 => [
+                    'text' => 'option 3',
+                    'value' => 12,
+                    'class' => 'custominputclass',
+                    'label' => [
+                        'class' => 'customlabelclass'
+                    ]
+                ],
+                'group' => [
+                    10 => 'option 4',
+                    20 => [
+                        'text' => 'option 4',
+                        'value' => 20,
+                        'class' => 'custominputclass'
+                    ],
+                    30 => [
+                        'text' => 'option 5 without label',
+                        'value' => 30,
+                        'label' => false
+                    ],
+                    40 => [
+                        'text' => 'option 6',
+                        'value' => 40,
+                        'label' => [
+                            'class' => 'customlabelclass'
+                        ]
+                    ],
+                ]
+            ],
+            'nestedInput' => true
+        ]);
+        $expected = [
+            ['fieldset' => ['class' => 'form-group multicheckbox']],
+                ['legend' => true],
+                    'Users',
+                '/legend',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'form-check']],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-1',
+                            'value' => 1
+                        ]],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check']],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-2',
+                            'value' => 2
+                        ]],
+                        'option 2',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check']],
+                    ['label' => ['class' => 'customlabelclass', 'for' => 'users-12']],
+                        ['input' => [
+                            'class' => 'custominputclass',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-12',
+                            'value' => 12
+                        ]],
+                        'option 3',
+                    '/label',
+                '/div',
+                ['fieldset' => true],
+                    ['legend' => true],
+                        'group',
+                    '/legend',
+                    ['div' => ['class' => 'form-check']],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-10']],
+                            ['input' => [
+                                'class' => 'form-check-input',
+                                'type' => 'checkbox',
+                                'name' => 'users[]',
+                                'id' => 'users-10',
+                                'value' => 10
+                            ]],
+                            'option 4',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'form-check']],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-20']],
+                            ['input' => [
+                                'class' => 'custominputclass',
+                                'type' => 'checkbox',
+                                'name' => 'users[]',
+                                'id' => 'users-20',
+                                'value' => 20
+                            ]],
+                            'option 4',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'form-check']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-30',
+                            'value' => 30
+                        ]],
+                    '/div',
+                    ['div' => ['class' => 'form-check']],
+                        ['label' => ['class' => 'customlabelclass', 'for' => 'users-40']],
+                            ['input' => [
+                                'class' => 'form-check-input',
+                                'type' => 'checkbox',
+                                'name' => 'users[]',
+                                'id' => 'users-40',
+                                'value' => 40
+                            ]],
+                            'option 6',
+                        '/label',
+                    '/div',
+                 '/fieldset',
+            '/fieldset',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignMultipleCheckboxControl()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7
+                ]
+            ]
+        ]);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2'
+            ]
+        ]);
+        $expected = [
+            ['fieldset' => ['class' => 'form-group multicheckbox']],
+                ['div' => ['class' => 'row']],
+                    ['legend' => ['class' => 'col-form-label pt-0 col-sm-5']],
+                        'Users',
+                    '/legend',
+                    ['div' => ['class' => 'col-sm-7']],
+                        ['input' => [
+                            'type' => 'hidden',
+                            'name' => 'users',
+                            'value' => '',
+                        ]],
+                        ['div' => ['class' => 'form-check']],
+                            ['input' => [
+                                'class' => 'form-check-input',
+                                'type' => 'checkbox',
+                                'name' => 'users[]',
+                                'id' => 'users-1',
+                                'value' => 1
+                            ]],
+                            ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                                'option 1',
+                            '/label',
+                        '/div',
+                        ['div' => ['class' => 'form-check']],
+                            ['input' => [
+                                'class' => 'form-check-input',
+                                'type' => 'checkbox',
+                                'name' => 'users[]',
+                                'id' => 'users-2',
+                                'value' => 2
+                            ]],
+                            ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                                'option 2',
+                            '/label',
+                        '/div',
+                    '/div',
+                '/div',
+            '/fieldset',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignMultipleCheckboxControlNestedInput()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7
+                ]
+            ]
+        ]);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2'
+            ],
+            'nestedInput' => true
+        ]);
+        $expected = [
+            ['fieldset' => ['class' => 'form-group multicheckbox']],
+                ['div' => ['class' => 'row']],
+                    ['legend' => ['class' => 'col-form-label pt-0 col-sm-5']],
+                        'Users',
+                    '/legend',
+                    ['div' => ['class' => 'col-sm-7']],
+                        ['input' => [
+                            'type' => 'hidden',
+                            'name' => 'users',
+                            'value' => '',
+                        ]],
+                        ['div' => ['class' => 'form-check']],
+                            ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                                ['input' => [
+                                    'class' => 'form-check-input',
+                                    'type' => 'checkbox',
+                                    'name' => 'users[]',
+                                    'id' => 'users-1',
+                                    'value' => 1
+                                ]],
+                                'option 1',
+                            '/label',
+                        '/div',
+                        ['div' => ['class' => 'form-check']],
+                            ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                                ['input' => [
+                                    'class' => 'form-check-input',
+                                    'type' => 'checkbox',
+                                    'name' => 'users[]',
+                                    'id' => 'users-2',
+                                    'value' => 2
+                                ]],
+                                'option 2',
+                            '/label',
+                        '/div',
+                    '/div',
+                '/div',
+            '/fieldset',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignMultipleCheckboxControlOptionGroups()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7
+                ]
+            ]
+        ]);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                'group 1' => [
+                    1 => 'option 1',
+                    2 => 'option 2'
+                ],
+                'group 2' => [
+                    3 => 'option 3',
+                    4 => 'option 4'
+                ],
+            ]
+        ]);
+        $expected = [
+            ['fieldset' => ['class' => 'form-group multicheckbox']],
+                ['div' => ['class' => 'row']],
+                    ['legend' => ['class' => 'col-form-label pt-0 col-sm-5']],
+                        'Users',
+                    '/legend',
+                    ['div' => ['class' => 'col-sm-7']],
+                        ['input' => [
+                            'type' => 'hidden',
+                            'name' => 'users',
+                            'value' => '',
+                        ]],
+                        ['fieldset' => true],
+                            ['legend' => true],
+                                'group 1',
+                            '/legend',
+                            ['div' => ['class' => 'form-check']],
+                                ['input' => [
+                                    'class' => 'form-check-input',
+                                    'type' => 'checkbox',
+                                    'name' => 'users[]',
+                                    'id' => 'users-1',
+                                    'value' => 1
+                                ]],
+                                ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                                    'option 1',
+                                '/label',
+                            '/div',
+                            ['div' => ['class' => 'form-check']],
+                                ['input' => [
+                                    'class' => 'form-check-input',
+                                    'type' => 'checkbox',
+                                    'name' => 'users[]',
+                                    'id' => 'users-2',
+                                    'value' => 2
+                                ]],
+                                ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                                    'option 2',
+                                '/label',
+                            '/div',
+                         '/fieldset',
+                        ['fieldset' => true],
+                            ['legend' => true],
+                                'group 2',
+                            '/legend',
+                            ['div' => ['class' => 'form-check']],
+                                ['input' => [
+                                    'class' => 'form-check-input',
+                                    'type' => 'checkbox',
+                                    'name' => 'users[]',
+                                    'id' => 'users-3',
+                                    'value' => 3
+                                ]],
+                                ['label' => ['class' => 'form-check-label', 'for' => 'users-3']],
+                                    'option 3',
+                                '/label',
+                            '/div',
+                            ['div' => ['class' => 'form-check']],
+                                ['input' => [
+                                    'class' => 'form-check-input',
+                                    'type' => 'checkbox',
+                                    'name' => 'users[]',
+                                    'id' => 'users-4',
+                                    'value' => 4
+                                ]],
+                                ['label' => ['class' => 'form-check-label', 'for' => 'users-4']],
+                                    'option 4',
+                                '/label',
+                            '/div',
+                         '/fieldset',
+                    '/div',
+                '/div',
+            '/fieldset',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignMultipleCheckboxControlOptionGroupsNestedInput()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7
+                ]
+            ]
+        ]);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                'group 1' => [
+                    1 => 'option 1',
+                    2 => 'option 2'
+                ],
+                'group 2' => [
+                    3 => 'option 3',
+                    4 => 'option 4'
+                ],
+            ],
+            'nestedInput' => true
+        ]);
+        $expected = [
+            ['fieldset' => ['class' => 'form-group multicheckbox']],
+                ['div' => ['class' => 'row']],
+                    ['legend' => ['class' => 'col-form-label pt-0 col-sm-5']],
+                        'Users',
+                    '/legend',
+                    ['div' => ['class' => 'col-sm-7']],
+                        ['input' => [
+                            'type' => 'hidden',
+                            'name' => 'users',
+                            'value' => '',
+                        ]],
+                        ['fieldset' => true],
+                            ['legend' => true],
+                                'group 1',
+                            '/legend',
+                            ['div' => ['class' => 'form-check']],
+                                ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                                    ['input' => [
+                                        'class' => 'form-check-input',
+                                        'type' => 'checkbox',
+                                        'name' => 'users[]',
+                                        'id' => 'users-1',
+                                        'value' => 1
+                                    ]],
+                                    'option 1',
+                                '/label',
+                            '/div',
+                            ['div' => ['class' => 'form-check']],
+                                ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                                    ['input' => [
+                                        'class' => 'form-check-input',
+                                        'type' => 'checkbox',
+                                        'name' => 'users[]',
+                                        'id' => 'users-2',
+                                        'value' => 2
+                                    ]],
+                                    'option 2',
+                                '/label',
+                            '/div',
+                         '/fieldset',
+                        ['fieldset' => true],
+                            ['legend' => true],
+                                'group 2',
+                            '/legend',
+                            ['div' => ['class' => 'form-check']],
+                                ['label' => ['class' => 'form-check-label', 'for' => 'users-3']],
+                                    ['input' => [
+                                        'class' => 'form-check-input',
+                                        'type' => 'checkbox',
+                                        'name' => 'users[]',
+                                        'id' => 'users-3',
+                                        'value' => 3
+                                    ]],
+                                    'option 3',
+                                '/label',
+                            '/div',
+                            ['div' => ['class' => 'form-check']],
+                                ['label' => ['class' => 'form-check-label', 'for' => 'users-4']],
+                                    ['input' => [
+                                        'class' => 'form-check-input',
+                                        'type' => 'checkbox',
+                                        'name' => 'users[]',
+                                        'id' => 'users-4',
+                                        'value' => 4
+                                    ]],
+                                    'option 4',
+                                '/label',
+                            '/div',
+                         '/fieldset',
+                    '/div',
+                '/div',
+            '/fieldset',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignMultipleCheckboxControlOptionsGroupsAndSingleEntries()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7
+                ]
+            ]
+        ]);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+                'group' => [
+                    3 => 'option 3',
+                    4 => 'option 4',
+                ]
+            ]
+        ]);
+        $expected = [
+            ['fieldset' => ['class' => 'form-group multicheckbox']],
+                ['div' => ['class' => 'row']],
+                    ['legend' => ['class' => 'col-form-label pt-0 col-sm-5']],
+                        'Users',
+                    '/legend',
+                    ['div' => ['class' => 'col-sm-7']],
+                        ['input' => [
+                            'type' => 'hidden',
+                            'name' => 'users',
+                            'value' => '',
+                        ]],
+                        ['div' => ['class' => 'form-check']],
+                            ['input' => [
+                                'class' => 'form-check-input',
+                                'type' => 'checkbox',
+                                'name' => 'users[]',
+                                'id' => 'users-1',
+                                'value' => 1
+                            ]],
+                            ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                                'option 1',
+                            '/label',
+                        '/div',
+                        ['div' => ['class' => 'form-check']],
+                            ['input' => [
+                                'class' => 'form-check-input',
+                                'type' => 'checkbox',
+                                'name' => 'users[]',
+                                'id' => 'users-2',
+                                'value' => 2
+                            ]],
+                            ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                                'option 2',
+                            '/label',
+                        '/div',
+                        ['fieldset' => true],
+                            ['legend' => true],
+                                'group',
+                            '/legend',
+                            ['div' => ['class' => 'form-check']],
+                                ['input' => [
+                                    'class' => 'form-check-input',
+                                    'type' => 'checkbox',
+                                    'name' => 'users[]',
+                                    'id' => 'users-3',
+                                    'value' => 3
+                                ]],
+                                ['label' => ['class' => 'form-check-label', 'for' => 'users-3']],
+                                    'option 3',
+                                '/label',
+                            '/div',
+                            ['div' => ['class' => 'form-check']],
+                                ['input' => [
+                                    'class' => 'form-check-input',
+                                    'type' => 'checkbox',
+                                    'name' => 'users[]',
+                                    'id' => 'users-4',
+                                    'value' => 4
+                                ]],
+                                ['label' => ['class' => 'form-check-label', 'for' => 'users-4']],
+                                    'option 4',
+                                '/label',
+                            '/div',
+                         '/fieldset',
+                    '/div',
+                '/div',
+            '/fieldset',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignMultipleCheckboxControlOptionsGroupsAndSingleEntriesWithPerOptionConfiguration()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7
+                ]
+            ]
+        ]);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+                4 => [
+                    'text' => 'option 3',
+                    'value' => 12,
+                    'class' => 'custominputclass',
+                    'label' => [
+                        'class' => 'customlabelclass'
+                    ]
+                ],
+                'group' => [
+                    10 => 'option 4',
+                    20 => [
+                        'text' => 'option 4',
+                        'value' => 20,
+                        'class' => 'custominputclass'
+                    ],
+                    30 => [
+                        'text' => 'option 5 without label',
+                        'value' => 30,
+                        'label' => false
+                    ],
+                    40 => [
+                        'text' => 'option 6',
+                        'value' => 40,
+                        'label' => [
+                            'class' => 'customlabelclass'
+                        ]
+                    ],
+                ]
+            ],
+        ]);
+        $expected = [
+            ['fieldset' => ['class' => 'form-group multicheckbox']],
+                ['div' => ['class' => 'row']],
+                    ['legend' => ['class' => 'col-form-label pt-0 col-sm-5']],
+                        'Users',
+                    '/legend',
+                    ['div' => ['class' => 'col-sm-7']],
+                        ['input' => [
+                            'type' => 'hidden',
+                            'name' => 'users',
+                            'value' => '',
+                        ]],
+                        ['div' => ['class' => 'form-check']],
+                            ['input' => [
+                                'class' => 'form-check-input',
+                                'type' => 'checkbox',
+                                'name' => 'users[]',
+                                'id' => 'users-1',
+                                'value' => 1
+                            ]],
+                            ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                                'option 1',
+                            '/label',
+                        '/div',
+                        ['div' => ['class' => 'form-check']],
+                            ['input' => [
+                                'class' => 'form-check-input',
+                                'type' => 'checkbox',
+                                'name' => 'users[]',
+                                'id' => 'users-2',
+                                'value' => 2
+                            ]],
+                            ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                                'option 2',
+                            '/label',
+                        '/div',
+                        ['div' => ['class' => 'form-check']],
+                            ['input' => [
+                                'class' => 'custominputclass',
+                                'type' => 'checkbox',
+                                'name' => 'users[]',
+                                'id' => 'users-12',
+                                'value' => 12
+                            ]],
+                            ['label' => ['class' => 'customlabelclass', 'for' => 'users-12']],
+                                'option 3',
+                            '/label',
+                        '/div',
+                        ['fieldset' => true],
+                            ['legend' => true],
+                                'group',
+                            '/legend',
+                            ['div' => ['class' => 'form-check']],
+                                ['input' => [
+                                    'class' => 'form-check-input',
+                                    'type' => 'checkbox',
+                                    'name' => 'users[]',
+                                    'id' => 'users-10',
+                                    'value' => 10
+                                ]],
+                                ['label' => ['class' => 'form-check-label', 'for' => 'users-10']],
+                                    'option 4',
+                                '/label',
+                            '/div',
+                            ['div' => ['class' => 'form-check']],
+                                ['input' => [
+                                    'class' => 'custominputclass',
+                                    'type' => 'checkbox',
+                                    'name' => 'users[]',
+                                    'id' => 'users-20',
+                                    'value' => 20
+                                ]],
+                                ['label' => ['class' => 'form-check-label', 'for' => 'users-20']],
+                                    'option 4',
+                                '/label',
+                            '/div',
+                            ['div' => ['class' => 'form-check']],
+                                ['input' => [
+                                    'class' => 'form-check-input',
+                                    'type' => 'checkbox',
+                                    'name' => 'users[]',
+                                    'id' => 'users-30',
+                                    'value' => 30
+                                ]],
+                            '/div',
+                            ['div' => ['class' => 'form-check']],
+                                ['input' => [
+                                    'class' => 'form-check-input',
+                                    'type' => 'checkbox',
+                                    'name' => 'users[]',
+                                    'id' => 'users-40',
+                                    'value' => 40
+                                ]],
+                                ['label' => ['class' => 'customlabelclass', 'for' => 'users-40']],
+                                    'option 6',
+                                '/label',
+                            '/div',
+                         '/fieldset',
+                    '/div',
+                '/div',
+            '/fieldset',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignMultipleCheckboxControlOptionsGroupsAndSingleEntriesNestedInput()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7
+                ]
+            ]
+        ]);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+                'group' => [
+                    3 => 'option 3',
+                    4 => 'option 4',
+                ]
+            ],
+            'nestedInput' => true
+        ]);
+        $expected = [
+            ['fieldset' => ['class' => 'form-group multicheckbox']],
+                ['div' => ['class' => 'row']],
+                    ['legend' => ['class' => 'col-form-label pt-0 col-sm-5']],
+                        'Users',
+                    '/legend',
+                    ['div' => ['class' => 'col-sm-7']],
+                        ['input' => [
+                            'type' => 'hidden',
+                            'name' => 'users',
+                            'value' => '',
+                        ]],
+                        ['div' => ['class' => 'form-check']],
+                            ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                                ['input' => [
+                                    'class' => 'form-check-input',
+                                    'type' => 'checkbox',
+                                    'name' => 'users[]',
+                                    'id' => 'users-1',
+                                    'value' => 1
+                                ]],
+                                'option 1',
+                            '/label',
+                        '/div',
+                        ['div' => ['class' => 'form-check']],
+                            ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                                ['input' => [
+                                    'class' => 'form-check-input',
+                                    'type' => 'checkbox',
+                                    'name' => 'users[]',
+                                    'id' => 'users-2',
+                                    'value' => 2
+                                ]],
+                                'option 2',
+                            '/label',
+                        '/div',
+                        ['fieldset' => true],
+                            ['legend' => true],
+                                'group',
+                            '/legend',
+                            ['div' => ['class' => 'form-check']],
+                                ['label' => ['class' => 'form-check-label', 'for' => 'users-3']],
+                                    ['input' => [
+                                        'class' => 'form-check-input',
+                                        'type' => 'checkbox',
+                                        'name' => 'users[]',
+                                        'id' => 'users-3',
+                                        'value' => 3
+                                    ]],
+                                    'option 3',
+                                '/label',
+                            '/div',
+                            ['div' => ['class' => 'form-check']],
+                                ['label' => ['class' => 'form-check-label', 'for' => 'users-4']],
+                                    ['input' => [
+                                        'class' => 'form-check-input',
+                                        'type' => 'checkbox',
+                                        'name' => 'users[]',
+                                        'id' => 'users-4',
+                                        'value' => 4
+                                    ]],
+                                    'option 4',
+                                '/label',
+                            '/div',
+                         '/fieldset',
+                    '/div',
+                '/div',
+            '/fieldset',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignMultipleCheckboxControlOptionsGroupsAndSingleEntriesWithPerOptionConfigurationNestedInput()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7
+                ]
+            ]
+        ]);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+                4 => [
+                    'text' => 'option 3',
+                    'value' => 12,
+                    'class' => 'custominputclass',
+                    'label' => [
+                        'class' => 'customlabelclass'
+                    ]
+                ],
+                'group' => [
+                    10 => 'option 4',
+                    20 => [
+                        'text' => 'option 4',
+                        'value' => 20,
+                        'class' => 'custominputclass'
+                    ],
+                    30 => [
+                        'text' => 'option 5 without label',
+                        'value' => 30,
+                        'label' => false
+                    ],
+                    40 => [
+                        'text' => 'option 6',
+                        'value' => 40,
+                        'label' => [
+                            'class' => 'customlabelclass'
+                        ]
+                    ],
+                ]
+            ],
+            'nestedInput' => true
+        ]);
+        $expected = [
+            ['fieldset' => ['class' => 'form-group multicheckbox']],
+                ['div' => ['class' => 'row']],
+                    ['legend' => ['class' => 'col-form-label pt-0 col-sm-5']],
+                        'Users',
+                    '/legend',
+                    ['div' => ['class' => 'col-sm-7']],
+                        ['input' => [
+                            'type' => 'hidden',
+                            'name' => 'users',
+                            'value' => '',
+                        ]],
+                        ['div' => ['class' => 'form-check']],
+                            ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                                ['input' => [
+                                    'class' => 'form-check-input',
+                                    'type' => 'checkbox',
+                                    'name' => 'users[]',
+                                    'id' => 'users-1',
+                                    'value' => 1
+                                ]],
+                                'option 1',
+                            '/label',
+                        '/div',
+                        ['div' => ['class' => 'form-check']],
+                            ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                                ['input' => [
+                                    'class' => 'form-check-input',
+                                    'type' => 'checkbox',
+                                    'name' => 'users[]',
+                                    'id' => 'users-2',
+                                    'value' => 2
+                                ]],
+                                'option 2',
+                            '/label',
+                        '/div',
+                        ['div' => ['class' => 'form-check']],
+                            ['label' => ['class' => 'customlabelclass', 'for' => 'users-12']],
+                                ['input' => [
+                                    'class' => 'custominputclass',
+                                    'type' => 'checkbox',
+                                    'name' => 'users[]',
+                                    'id' => 'users-12',
+                                    'value' => 12
+                                ]],
+                                'option 3',
+                            '/label',
+                        '/div',
+                        ['fieldset' => true],
+                            ['legend' => true],
+                                'group',
+                            '/legend',
+                            ['div' => ['class' => 'form-check']],
+                                ['label' => ['class' => 'form-check-label', 'for' => 'users-10']],
+                                    ['input' => [
+                                        'class' => 'form-check-input',
+                                        'type' => 'checkbox',
+                                        'name' => 'users[]',
+                                        'id' => 'users-10',
+                                        'value' => 10
+                                    ]],
+                                    'option 4',
+                                '/label',
+                            '/div',
+                            ['div' => ['class' => 'form-check']],
+                                ['label' => ['class' => 'form-check-label', 'for' => 'users-20']],
+                                    ['input' => [
+                                        'class' => 'custominputclass',
+                                        'type' => 'checkbox',
+                                        'name' => 'users[]',
+                                        'id' => 'users-20',
+                                        'value' => 20
+                                    ]],
+                                    'option 4',
+                                '/label',
+                            '/div',
+                            ['div' => ['class' => 'form-check']],
+                                ['input' => [
+                                    'class' => 'form-check-input',
+                                    'type' => 'checkbox',
+                                    'name' => 'users[]',
+                                    'id' => 'users-30',
+                                    'value' => 30
+                                ]],
+                            '/div',
+                            ['div' => ['class' => 'form-check']],
+                                ['label' => ['class' => 'customlabelclass', 'for' => 'users-40']],
+                                    ['input' => [
+                                        'class' => 'form-check-input',
+                                        'type' => 'checkbox',
+                                        'name' => 'users[]',
+                                        'id' => 'users-40',
+                                        'value' => 40
+                                    ]],
+                                    'option 6',
+                                '/label',
+                            '/div',
+                         '/fieldset',
+                    '/div',
+                '/div',
+            '/fieldset',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testInlineAlignMultipleCheckboxControl()
+    {
+        $this->withErrorReporting(0, function () {
+            $this->Form->create($this->article, [
+                'align' => 'inline'
+            ]);
+        });
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2'
+            ]
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group multicheckbox']],
+                ['span' => ['class' => 'sr-only']],
+                    'Users',
+                '/span',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-1',
+                        'value' => 1
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-2',
+                        'value' => 2
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testInlineAlignMultipleCheckboxControlWithPerOptionConfiguration()
+    {
+        $this->withErrorReporting(0, function () {
+            $this->Form->create($this->article, [
+                'align' => 'inline'
+            ]);
+        });
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+                4 => [
+                    'text' => 'option 3',
+                    'value' => 12,
+                    'class' => 'custominputclass',
+                    'label' => [
+                        'class' => 'customlabelclass'
+                    ]
+                ],
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group multicheckbox']],
+                ['span' => ['class' => 'sr-only']],
+                    'Users',
+                '/span',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-1',
+                        'value' => 1
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-2',
+                        'value' => 2
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['input' => [
+                        'class' => 'custominputclass',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-12',
+                        'value' => 12
+                    ]],
+                    ['label' => ['class' => 'customlabelclass', 'for' => 'users-12']],
+                        'option 3',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testInlineAlignMultipleCheckboxControlNestedInput()
+    {
+        $this->withErrorReporting(0, function () {
+            $this->Form->create($this->article, [
+                'align' => 'inline'
+            ]);
+        });
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2'
+            ],
+            'nestedInput' => true
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group multicheckbox']],
+                ['span' => ['class' => 'sr-only']],
+                    'Users',
+                '/span',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-1',
+                            'value' => 1
+                        ]],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-2',
+                            'value' => 2
+                        ]],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testInlineAlignMultipleCheckboxControlWithPerOptionConfigurationNestedInput()
+    {
+        $this->withErrorReporting(0, function () {
+            $this->Form->create($this->article, [
+                'align' => 'inline'
+            ]);
+        });
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+                4 => [
+                    'text' => 'option 3',
+                    'value' => 12,
+                    'class' => 'custominputclass',
+                    'label' => [
+                        'class' => 'customlabelclass'
+                    ]
+                ],
+            ],
+            'nestedInput' => true
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group multicheckbox']],
+                ['span' => ['class' => 'sr-only']],
+                    'Users',
+                '/span',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-1',
+                            'value' => 1
+                        ]],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-2',
+                            'value' => 2
+                        ]],
+                        'option 2',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['label' => ['class' => 'customlabelclass', 'for' => 'users-12']],
+                        ['input' => [
+                            'class' => 'custominputclass',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-12',
+                            'value' => 12
+                        ]],
+                        'option 3',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
 }


### PR DESCRIPTION
Instead of waiting till I can get everything working, I thought I'd push things out incrementally per control, this has been on the back burner for way too long already :/

Nested inputs for multi option controls required the changes in #242 to be altered a bit, in order to avoid duplicate inputs, and to retain the ability the disable labels per option configuration - hopefully this won't come back to bite me with the remaining controls.

[**Errors aren't displayed properly**](https://github.com/FriendsOfCake/bootstrap-ui/issues/223#issuecomment-405334736) yet, but this is also true for other controls, so I'm going to work on that later on when all controls are rendering the correct markup.

For reference

* https://getbootstrap.com/docs/4.1/components/forms/#horizontal-form
* https://getbootstrap.com/docs/4.1/components/forms/#inline
* #223