### PR TITLE
BS4 Compatibility - Datetime Control

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -41,10 +41,6 @@ class FormHelper extends Helper
         'dateWidgetPart' => '<li class="list-inline-item {{part}}"><select name="{{name}}"{{attrs}}>{{content}}</select></li>',
         'datetimeContainer' => '<div class="form-group {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}{{help}}</div>',
         'datetimeContainerError' => '<div class="form-group {{type}}{{required}} is-invalid" role="group" aria-labelledby="{{groupId}}">{{content}}{{error}}{{help}}</div>',
-        'dateContainer' => '<div class="form-group {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}{{help}}</div>',
-        'dateContainerError' => '<div class="form-group {{type}}{{required}} is-invalid" role="group" aria-labelledby="{{groupId}}">{{content}}{{error}}{{help}}</div>',
-        'timeContainer' => '<div class="form-group {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}{{help}}</div>',
-        'timeContainerError' => '<div class="form-group {{type}}{{required}} is-invalid" role="group" aria-labelledby="{{groupId}}">{{content}}{{error}}{{help}}</div>',
         'datetimeLabel' => '<label id="{{groupId}}">{{text}}</label>',
         'inputContainer' => '<div class="form-group {{type}}{{required}}">{{content}}{{help}}</div>',
         'inputContainerError' => '<div class="form-group {{type}}{{required}} is-invalid">{{content}}{{error}}{{help}}</div>',
@@ -85,10 +81,6 @@ class FormHelper extends Helper
             'label' => '<label class="sr-only"{{attrs}}>{{text}}{{tooltip}}</label>',
             'datetimeContainer' => '<div class="form-group {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
             'datetimeContainerError' => '<div class="form-group {{type}}{{required}} is-invalid" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
-            'dateContainer' => '<div class="form-group {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
-            'dateContainerError' => '<div class="form-group {{type}}{{required}} is-invalid" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
-            'timeContainer' => '<div class="form-group {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
-            'timeContainerError' => '<div class="form-group {{type}}{{required}} is-invalid" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
             'datetimeLabel' => '<span id="{{groupId}}" class="sr-only">{{text}}</span>',
             'inputContainer' => '{{content}}',
             'radioContainer' => '<div class="form-group {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
@@ -105,10 +97,6 @@ class FormHelper extends Helper
             'checkboxFormGroup' => '<div class="%s"><div class="form-check">{{input}}{{label}}</div>{{error}}{{help}}</div>',
             'datetimeContainer' => '<div class="form-group row {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
             'datetimeContainerError' => '<div class="form-group row {{type}}{{required}} is-invalid" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
-            'dateContainer' => '<div class="form-group row {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
-            'dateContainerError' => '<div class="form-group row {{type}}{{required}} is-invalid" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
-            'timeContainer' => '<div class="form-group row {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
-            'timeContainerError' => '<div class="form-group row {{type}}{{required}} is-invalid" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
             'datetimeLabel' => '<label id="{{groupId}}" class="col-form-label %s">{{text}}</label>',
             'checkboxInlineFormGroup' => '<div class="%s"><div class="form-check form-check-inline">{{input}}{{label}}</div></div>',
             'submitContainer' => '<div class="form-group"><div class="%s">{{content}}</div></div>',
@@ -303,6 +291,8 @@ class FormHelper extends Helper
                 $options['templateVars']['groupId'] = $this->_domId($fieldName . '-group-label');
                 $options['templates']['label'] = $this->templater()->get('datetimeLabel');
                 $options['templates']['select'] = $this->templater()->get('dateWidgetPart');
+                $options['templates']['inputContainer'] = $this->templater()->get('datetimeContainer');
+                $options['templates']['inputContainerError'] = $this->templater()->get('datetimeContainerError');
                 break;
 
             case 'checkbox':

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -33,11 +33,19 @@ class FormHelper extends Helper
      * @var array
      */
     protected $_templates = [
-        'dateWidget' => '<ul class="list-inline"><li class="year">{{year}}</li><li class="month">{{month}}</li><li class="day">{{day}}</li><li class="hour">{{hour}}</li><li class="minute">{{minute}}</li><li class="second">{{second}}</li><li class="meridian">{{meridian}}</li></ul>',
         'error' => '<div class="invalid-feedback">{{content}}</div>',
         'label' => '<label{{attrs}}>{{text}}{{tooltip}}</label>',
         'help' => '<small{{attrs}} class="form-text text-muted">{{content}}</small>',
         'tooltip' => '<span data-toggle="tooltip" title="{{content}}" class="fas fa-info-circle"></span>',
+        'dateWidget' => '<ul class="list-inline">{{year}}{{month}}{{day}}{{hour}}{{minute}}{{second}}{{meridian}}</ul>',
+        'dateWidgetPart' => '<li class="list-inline-item {{part}}"><select name="{{name}}"{{attrs}}>{{content}}</select></li>',
+        'datetimeContainer' => '<div class="form-group {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}{{help}}</div>',
+        'datetimeContainerError' => '<div class="form-group {{type}}{{required}} is-invalid" role="group" aria-labelledby="{{groupId}}">{{content}}{{error}}{{help}}</div>',
+        'dateContainer' => '<div class="form-group {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}{{help}}</div>',
+        'dateContainerError' => '<div class="form-group {{type}}{{required}} is-invalid" role="group" aria-labelledby="{{groupId}}">{{content}}{{error}}{{help}}</div>',
+        'timeContainer' => '<div class="form-group {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}{{help}}</div>',
+        'timeContainerError' => '<div class="form-group {{type}}{{required}} is-invalid" role="group" aria-labelledby="{{groupId}}">{{content}}{{error}}{{help}}</div>',
+        'datetimeLabel' => '<label id="{{groupId}}">{{text}}</label>',
         'inputContainer' => '<div class="form-group {{type}}{{required}}">{{content}}{{help}}</div>',
         'inputContainerError' => '<div class="form-group {{type}}{{required}} is-invalid">{{content}}{{error}}{{help}}</div>',
         'checkboxContainer' => '<div class="form-group form-check {{type}}{{required}}">{{content}}{{help}}</div>',
@@ -75,6 +83,13 @@ class FormHelper extends Helper
         ],
         'inline' => [
             'label' => '<label class="sr-only"{{attrs}}>{{text}}{{tooltip}}</label>',
+            'datetimeContainer' => '<div class="form-group {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
+            'datetimeContainerError' => '<div class="form-group {{type}}{{required}} is-invalid" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
+            'dateContainer' => '<div class="form-group {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
+            'dateContainerError' => '<div class="form-group {{type}}{{required}} is-invalid" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
+            'timeContainer' => '<div class="form-group {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
+            'timeContainerError' => '<div class="form-group {{type}}{{required}} is-invalid" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
+            'datetimeLabel' => '<span id="{{groupId}}" class="sr-only">{{text}}</span>',
             'inputContainer' => '{{content}}',
             'radioContainer' => '<div class="form-group {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
             'radioContainerError' => '<div class="form-group {{type}}{{required}} is-invalid" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
@@ -88,6 +103,13 @@ class FormHelper extends Helper
             'fileLabel' => '<label class="col-form-label pt-1 %s"{{attrs}}>{{text}}{{tooltip}}</label>',
             'formGroup' => '{{label}}<div class="%s">{{input}}{{error}}{{help}}</div>',
             'checkboxFormGroup' => '<div class="%s"><div class="form-check">{{input}}{{label}}</div>{{error}}{{help}}</div>',
+            'datetimeContainer' => '<div class="form-group row {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
+            'datetimeContainerError' => '<div class="form-group row {{type}}{{required}} is-invalid" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
+            'dateContainer' => '<div class="form-group row {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
+            'dateContainerError' => '<div class="form-group row {{type}}{{required}} is-invalid" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
+            'timeContainer' => '<div class="form-group row {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
+            'timeContainerError' => '<div class="form-group row {{type}}{{required}} is-invalid" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
+            'datetimeLabel' => '<label id="{{groupId}}" class="col-form-label %s">{{text}}</label>',
             'checkboxInlineFormGroup' => '<div class="%s"><div class="form-check form-check-inline">{{input}}{{label}}</div></div>',
             'submitContainer' => '<div class="form-group"><div class="%s">{{content}}</div></div>',
             'inputContainer' => '<div class="form-group row {{type}}{{required}}">{{content}}</div>',
@@ -273,6 +295,14 @@ class FormHelper extends Helper
         }
 
         switch ($options['type']) {
+            case 'datetime':
+            case 'date':
+            case 'time':
+                $options['templateVars']['groupId'] = $this->_domId($fieldName . '-group-label');
+                $options['templates']['label'] = $this->templater()->get('datetimeLabel');
+                $options['templates']['select'] = $this->templater()->get('dateWidgetPart');
+                break;
+
             case 'checkbox':
                 $options['label'] = $this->injectClasses('form-check-label', (array)$options['label']);
                 $options = $this->injectClasses('form-check-input', $options);
@@ -605,6 +635,34 @@ class FormHelper extends Helper
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function _datetimeOptions($options)
+    {
+        $options = parent::_datetimeOptions($options);
+
+        $errorClass = $this->getConfig('errorClass');
+        $hasError = $this->hasAnyClass($errorClass, $options);
+
+        foreach ($this->_datetimeParts as $part) {
+            if (isset($options[$part]) &&
+                $options[$part] !== false
+            ) {
+                if ($hasError) {
+                    $options[$part] = $this->addClass($options[$part], $errorClass);
+                }
+
+                $options[$part] += ['templateVars' => []];
+                $options[$part]['templateVars'] += [
+                    'part' => $part
+                ];
+            }
+        }
+
+        return $options;
+    }
+
+    /**
      * Form alignment detector/switcher.
      *
      * @param array $options Options.
@@ -653,6 +711,7 @@ class FormHelper extends Helper
         $offsetedGridClass = implode(' ', [$this->_gridClass('left', true), $this->_gridClass('middle')]);
 
         $templates['label'] = sprintf($templates['label'], $this->_gridClass('left'));
+        $templates['datetimeLabel'] = sprintf($templates['datetimeLabel'], $this->_gridClass('left'));
         $templates['radioLabel'] = sprintf($templates['radioLabel'], $this->_gridClass('left'));
         $templates['fileLabel'] = sprintf($templates['fileLabel'], $this->_gridClass('left'));
         $templates['multicheckboxLabel'] = sprintf($templates['multicheckboxLabel'], $this->_gridClass('left'));

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -298,6 +298,8 @@ class FormHelper extends Helper
             case 'datetime':
             case 'date':
             case 'time':
+                $options['hasError'] = $this->_getContext()->hasError($fieldName);
+
                 $options['templateVars']['groupId'] = $this->_domId($fieldName . '-group-label');
                 $options['templates']['label'] = $this->templater()->get('datetimeLabel');
                 $options['templates']['select'] = $this->templater()->get('dateWidgetPart');
@@ -642,7 +644,8 @@ class FormHelper extends Helper
         $options = parent::_datetimeOptions($options);
 
         $errorClass = $this->getConfig('errorClass');
-        $hasError = $this->hasAnyClass($errorClass, $options);
+        $hasError = isset($options['hasError']) && $options['hasError'] === true;
+        unset($options['hasError']);
 
         foreach ($this->_datetimeParts as $part) {
             if (isset($options[$part]) &&

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -31,6 +31,19 @@ class FormHelperTest extends TestCase
     public $article;
 
     /**
+     * @var array
+     */
+    public $dateRegex = [
+        'daysRegex' => 'preg:/(?:<option value="0?([\d]+)">\\1<\/option>[\r\n]*)*/',
+        'monthsRegex' => 'preg:/(?:<option value="[\d]+">[\w]+<\/option>[\r\n]*)*/',
+        'yearsRegex' => 'preg:/(?:<option value="([\d]+)">\\1<\/option>[\r\n]*)*/',
+        'hoursRegex' => 'preg:/(?:<option value="0?([\d]+)">\\1<\/option>[\r\n]*)*/',
+        'minutesRegex' => 'preg:/(?:<option value="([\d]+)">0?\\1<\/option>[\r\n]*)*/',
+        'secondsRegex' => 'preg:/(?:<option value="([\d]+)">0?\\1<\/option>[\r\n]*)*/',
+        'meridianRegex' => 'preg:/(?:<option value="(am|pm)">\\1<\/option>[\r\n]*)*/',
+    ];
+
+    /**
      * setUp method
      *
      * @return void
@@ -1678,6 +1691,277 @@ class FormHelperTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->Form->create($this->article, ['align' => 'foo']);
+    }
+
+    public function testDefaultAlignDatetimeControl()
+    {
+        $this->Form->create($this->article);
+
+        $now = time();
+
+        $result = $this->Form->control('created', [
+            'type' => 'datetime',
+            'timeFormat' => 12,
+            'second' => true,
+            'value' => $now,
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group datetime', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
+                ['label' => ['id' => 'created-group-label']],
+                    'Created',
+                '/label',
+                ['ul' => ['class' => 'list-inline']],
+                    ['li' => ['class' => 'list-inline-item year']],
+                        ['select' => ['name' => 'created[year]', 'class' => 'form-control']],
+                            $this->dateRegex['yearsRegex'],
+                            ['option' => ['value' => date('Y', $now), 'selected' => 'selected']],
+                                date('Y', $now),
+                            '/option',
+                        '*/select',
+                    '/li',
+                    ['li' => ['class' => 'list-inline-item month']],
+                        ['select' => ['name' => 'created[month]', 'class' => 'form-control']],
+                            $this->dateRegex['monthsRegex'],
+                            ['option' => ['value' => date('m', $now), 'selected' => 'selected']],
+                                date('F', $now),
+                            '/option',
+                        '*/select',
+                    '/li',
+                    ['li' => ['class' => 'list-inline-item day']],
+                        ['select' => ['name' => 'created[day]', 'class' => 'form-control']],
+                            $this->dateRegex['daysRegex'],
+                            ['option' => ['value' => date('d', $now), 'selected' => 'selected']],
+                                date('j', $now),
+                            '/option',
+                        '*/select',
+                    '/li',
+                    ['li' => ['class' => 'list-inline-item hour']],
+                        ['select' => ['name' => 'created[hour]', 'class' => 'form-control']],
+                            $this->dateRegex['hoursRegex'],
+                            ['option' => ['value' => date('H', $now), 'selected' => 'selected']],
+                                date('G', $now),
+                            '/option',
+                        '*/select',
+                    '/li',
+                    ['li' => ['class' => 'list-inline-item minute']],
+                        ['select' => ['name' => 'created[minute]', 'class' => 'form-control']],
+                            $this->dateRegex['minutesRegex'],
+                            ['option' => ['value' => date('i', $now), 'selected' => 'selected']],
+                                date('i', $now),
+                            '/option',
+                        '*/select',
+                    '/li',
+                    ['li' => ['class' => 'list-inline-item second']],
+                        ['select' => ['name' => 'created[second]', 'class' => 'form-control']],
+                            $this->dateRegex['secondsRegex'],
+                            ['option' => ['value' => date('s', $now), 'selected' => 'selected']],
+                                date('s', $now),
+                            '/option',
+                        '*/select',
+                    '/li',
+                    ['li' => ['class' => 'list-inline-item meridian']],
+                        ['select' => ['name' => 'created[meridian]', 'class' => 'form-control']],
+                            $this->dateRegex['meridianRegex'],
+                            ['option' => ['value' => date('a', $now), 'selected' => 'selected']],
+                                date('a', $now),
+                            '/option',
+                        '*/select',
+                    '/li',
+                '/ul',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignDatetimeControlDate()
+    {
+        $this->Form->create($this->article);
+
+        $now = time();
+
+        $result = $this->Form->control('created', [
+            'type' => 'date',
+            'value' => $now,
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group date', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
+                ['label' => ['id' => 'created-group-label']],
+                    'Created',
+                '/label',
+                ['ul' => ['class' => 'list-inline']],
+                    ['li' => ['class' => 'list-inline-item year']],
+                        ['select' => ['name' => 'created[year]', 'class' => 'form-control']],
+                            $this->dateRegex['yearsRegex'],
+                            ['option' => ['value' => date('Y', $now), 'selected' => 'selected']],
+                                date('Y', $now),
+                            '/option',
+                        '*/select',
+                    '/li',
+                    ['li' => ['class' => 'list-inline-item month']],
+                        ['select' => ['name' => 'created[month]', 'class' => 'form-control']],
+                            $this->dateRegex['monthsRegex'],
+                            ['option' => ['value' => date('m', $now), 'selected' => 'selected']],
+                                date('F', $now),
+                            '/option',
+                        '*/select',
+                    '/li',
+                    ['li' => ['class' => 'list-inline-item day']],
+                        ['select' => ['name' => 'created[day]', 'class' => 'form-control']],
+                            $this->dateRegex['daysRegex'],
+                            ['option' => ['value' => date('d', $now), 'selected' => 'selected']],
+                                date('j', $now),
+                            '/option',
+                        '*/select',
+                    '/li',
+                '/ul',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignDatetimeControlTime()
+    {
+        $this->Form->create($this->article);
+
+        $now = time();
+
+        $result = $this->Form->control('created', [
+            'type' => 'time',
+            'timeFormat' => 12,
+            'second' => true,
+            'value' => $now,
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group time', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
+                ['label' => ['id' => 'created-group-label']],
+                    'Created',
+                '/label',
+                ['ul' => ['class' => 'list-inline']],
+                    ['li' => ['class' => 'list-inline-item hour']],
+                        ['select' => ['name' => 'created[hour]', 'class' => 'form-control']],
+                            $this->dateRegex['hoursRegex'],
+                            ['option' => ['value' => date('H', $now), 'selected' => 'selected']],
+                                date('G', $now),
+                            '/option',
+                        '*/select',
+                    '/li',
+                    ['li' => ['class' => 'list-inline-item minute']],
+                        ['select' => ['name' => 'created[minute]', 'class' => 'form-control']],
+                            $this->dateRegex['minutesRegex'],
+                            ['option' => ['value' => date('i', $now), 'selected' => 'selected']],
+                                date('i', $now),
+                            '/option',
+                        '*/select',
+                    '/li',
+                    ['li' => ['class' => 'list-inline-item second']],
+                        ['select' => ['name' => 'created[second]', 'class' => 'form-control']],
+                            $this->dateRegex['secondsRegex'],
+                            ['option' => ['value' => date('s', $now), 'selected' => 'selected']],
+                                date('s', $now),
+                            '/option',
+                        '*/select',
+                    '/li',
+                    ['li' => ['class' => 'list-inline-item meridian']],
+                        ['select' => ['name' => 'created[meridian]', 'class' => 'form-control']],
+                            $this->dateRegex['meridianRegex'],
+                            ['option' => ['value' => date('a', $now), 'selected' => 'selected']],
+                                date('a', $now),
+                            '/option',
+                        '*/select',
+                    '/li',
+                '/ul',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignDatetimeControlCustomContainerTemplateViaTemplater()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('created', [
+            'type' => 'datetime',
+        ]);
+        $this->assertContains('<div class="form-group datetime" role="group" aria-labelledby="created-group-label">', $result);
+
+        $result = $this->Form->control('created', [
+            'type' => 'date',
+        ]);
+        $this->assertContains('<div class="form-group date" role="group" aria-labelledby="created-group-label">', $result);
+
+        $result = $this->Form->control('created', [
+            'type' => 'time',
+        ]);
+        $this->assertContains('<div class="form-group time" role="group" aria-labelledby="created-group-label">', $result);
+
+        $this->Form->setTemplates([
+            'datetimeContainer' => '<div class="custom datetimeContainer {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
+            'dateContainer' => '<div class="custom dateContainer {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
+            'timeContainer' => '<div class="custom timeContainer {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
+        ]);
+        $result = $this->Form->control('created', [
+            'type' => 'datetime',
+        ]);
+        $this->assertContains('<div class="custom datetimeContainer datetime" role="group" aria-labelledby="created-group-label">', $result);
+
+        $result = $this->Form->control('created', [
+            'type' => 'date',
+        ]);
+        $this->assertContains('<div class="custom dateContainer date" role="group" aria-labelledby="created-group-label">', $result);
+
+        $result = $this->Form->control('created', [
+            'type' => 'time',
+        ]);
+        $this->assertContains('<div class="custom timeContainer time" role="group" aria-labelledby="created-group-label">', $result);
+    }
+
+    public function testDefaultAlignDatetimeControlCustomContainerErrorTemplateViaOptions()
+    {
+        $this->article['errors'] = [
+            'created' => [
+                'foo' => 'bar'
+            ]
+        ];
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('created', [
+            'type' => 'datetime',
+        ]);
+        $this->assertContains('<div class="form-group datetime is-invalid" role="group" aria-labelledby="created-group-label">', $result);
+
+        $result = $this->Form->control('created', [
+            'type' => 'date',
+        ]);
+        $this->assertContains('<div class="form-group date is-invalid" role="group" aria-labelledby="created-group-label">', $result);
+
+        $result = $this->Form->control('created', [
+            'type' => 'time',
+        ]);
+        $this->assertContains('<div class="form-group time is-invalid" role="group" aria-labelledby="created-group-label">', $result);
+
+        $result = $this->Form->control('created', [
+            'type' => 'datetime',
+            'templates' => [
+                'datetimeContainerError' => '<div class="custom datetimeContainerError {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}</div>'
+            ]
+        ]);
+        $this->assertContains('<div class="custom datetimeContainerError datetime" role="group" aria-labelledby="created-group-label">', $result);
+
+        $result = $this->Form->control('created', [
+            'type' => 'date',
+            'templates' => [
+                'dateContainerError' => '<div class="custom dateContainerError {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}</div>'
+            ]
+        ]);
+        $this->assertContains('<div class="custom dateContainerError date" role="group" aria-labelledby="created-group-label">', $result);
+
+        $result = $this->Form->control('created', [
+            'type' => 'time',
+            'templates' => [
+                'timeContainerError' => '<div class="custom timeContainerError {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}</div>'
+            ]
+        ]);
+        $this->assertContains('<div class="custom timeContainerError time" role="group" aria-labelledby="created-group-label">', $result);
     }
 
     public function testDefaultAlignCheckboxControl()


### PR DESCRIPTION
This started pretty innocuous, I just wanted to add the `list-inline-item` class to the list elements, so that they are propery aligned.

The widget parts required a separate template so that empty parts do not leave empty list entries, as they are affecting the layout, causing additional space before time only controls, and after date only controls. In order to avoid having to create a separate template for each part, and possibly also its error variants, the part and error class are being injected in the overriden `_datetimeOptions()` method.

The way how an error is being detected might not be overly appreciated, ie checking whether the error class exists in the options. Another way would be checking explicitly for an error via the form context in the `control()` method, and passing the error state into the options, doing that would also allow using an extra error template (`dateWidgetPartError`), and/or using a custom/extended datetime widget, which could also be used for injecting the part class.

No tests yet, but the test app has been updated with additional date widget variants.

On a somewhat related note, that's a lot of additional templates, once we have all controls working, we might want to check if we can reduce them, there's quite some duplication.