### PR TITLE
BS4 Compatibility - Custom Form Elements

### DIFF
--- a/src/View/Widget/FileWidget.php
+++ b/src/View/Widget/FileWidget.php
@@ -3,6 +3,8 @@ namespace BootstrapUI\View\Widget;
 
 use BootstrapUI\View\Widget\InputgroupTrait;
 use Cake\View\Form\ContextInterface;
+use Cake\View\StringTemplate;
+use Cake\View\Widget\LabelWidget;
 
 /**
  * Input widget class for generating a file upload control.
@@ -10,6 +12,26 @@ use Cake\View\Form\ContextInterface;
 class FileWidget extends \Cake\View\Widget\FileWidget
 {
     use InputgroupTrait;
+
+    /**
+     * Label widget.
+     *
+     * @var \Cake\View\Widget\LabelWidget
+     */
+    protected $_label;
+
+    /**
+     * Constructor
+     *
+     * @param \Cake\View\StringTemplate $templates Templates list.
+     * @param \Cake\View\Widget\LabelWidget $label Label widget instance.
+     */
+    public function __construct(StringTemplate $templates, LabelWidget $label)
+    {
+        $this->_label = $label;
+
+        parent::__construct($templates);
+    }
 
     /**
      * Render a file upload form widget.
@@ -30,7 +52,24 @@ class FileWidget extends \Cake\View\Widget\FileWidget
     public function render(array $data, ContextInterface $context)
     {
         $data['injectFormControl'] = false;
-        $data = $this->injectClasses('form-control-file', $data);
+
+        $inputClass = 'form-control-file';
+        if (isset($data['custom']) &&
+            $data['custom']
+        ) {
+            $inputClass = 'custom-file-input';
+        }
+        unset($data['custom']);
+
+        $data = $this->injectClasses($inputClass, $data);
+
+        if (isset($data['inputGroupLabel'])) {
+            $data['inputGroupLabel'] += [
+                'for' => $data['id']
+            ];
+            $data['templateVars']['label'] = $this->_label->render($data['inputGroupLabel'], $context);
+            unset($data['inputGroupLabel']);
+        }
 
         return $this->_withInputGroup($data, $context);
     }


### PR DESCRIPTION
This should cover all supported custom controls, (multi) checkbox, radio, select, file, and even range... and yes, of course it introduces more templates, more complexity, and more headaches for all the unfortunate people that try to understand it :)

Getting the file label into the input group by rendering it into a template variable in the widget, is the cleanest solution I could come up with so far without making larger structural changes to input group handling in general, which doesn't seem worth the hassle right now, given that currently the file control is the only control that requires this special input group markup.

The controls seem to look and work fine, with a few exceptions (all of which are dictated by bootstrap), nesting inputs isn't supported, checkboxes/radios without labels aren't supported, the file control label is off in inline forms, and the range input doesn't support error/validation feedback.

No tests yet, but the test app has been updated accordingly.

For reference:

* https://getbootstrap.com/docs/4.1/components/forms/#custom-forms
* https://getbootstrap.com/docs/4.1/components/input-group/#custom-forms