### PR TITLE
Do not check for NPM on Windows

### DIFF
--- a/src/Shell/Task/TwbsAssetsTask.php
+++ b/src/Shell/Task/TwbsAssetsTask.php
@@ -38,7 +38,7 @@ class TwbsAssetsTask extends Shell
     public function installAssets()
     {
         $this->info('Checking npm...');
-        if (!`which npm`) {
+        if (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN' && !`which npm`) {
             $this->abort('NPM (https://www.npmjs.com/) is required, but not installed. Aborting.');
         }
 


### PR DESCRIPTION
This check doesn't work on Windows.

Alternatively one could check by executing npm --version.