### PR TITLE
CSS dashboard - lacking arrow 4 asc and desc sort

### DIFF
--- a/webroot/css/dashboard.css
+++ b/webroot/css/dashboard.css
@@ -11,6 +11,15 @@ body {
 /*
  * Global add-ons
  */
+/* added default values for sorting classes 
+ * found in style.css display gently small icons 
+ * beside sorted column header 
+ */
+.asc:after {content: " \2193";}
+.desc:after {content: " \2191";}
+/* these ones are funkies */
+/* .asc:after { content: " \e155"; }*/
+/* .desc:after { content: " \e156";}*/
 
 .sub-header {
   padding-bottom: 10px;


### PR DESCRIPTION
## Description

### Actual Behavior

sorted column headers are not automagically gently displayed
with a small icon (arrow, whatever, …)
Even if in the html code a class "asc" or "desc" is generated,
these class are not considered by BootstrapUI css file.

### Expected Behavior
by default sorted column headers should be displayed with an icon beside.
The classes "asc" and "desc" should be displayed if necessary

## Summarize
I added this code in
vendor/friendsofcake/bootstrap-ui/webroot/css/dashboard.css.

```css
.asc:after {content: " \2193";}
.desc:after {content: " \2191";}
```

## Benefits
This code solves the lack of BootStrapUI css dashboard
and now display gently small icons beside sorted columns header

Related Issues
This PR addresses the following issues.
fixes FriendsOfCake#280
