### PR TITLE
Fixing undefined index

### DIFF
--- a/templates/layout/examples/dashboard.php
+++ b/templates/layout/examples/dashboard.php
@@ -26,7 +26,7 @@ $this->start('tb_body_start');
                 </div>
             </nav>
             <main role="main" class="col-md-9 ml-sm-auto col-lg-10 pt-3 px-4">
-                <h1 class="page-header"><?= $this->request->controller; ?></h1>
+                <h1 class="page-header"><?= $this->request->getParam('controller'); ?></h1>
 <?php
 /**
  * Default `flash` block.


### PR DESCRIPTION
## Description
Fixed undefined var `$this->request->controller`

## Summarize
Write a list of the changes that were made.

- Using `$this->request->getParam('controller')` instead

## Benefits
No more undefined property
