### PR TITLE
Add support for tooltip error feedback

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -379,8 +379,8 @@ class FormHelper extends Helper
         ];
         $options = $this->_parseOptions($fieldName, $options);
 
-        $formGroupPosition = $options['formGroupPosition'];
-        $errorStyle = $options['errorStyle'];
+        $formGroupPosition = $options['formGroupPosition'] ?: $this->getConfig('formGroupPosition');
+        $errorStyle = $options['errorStyle'] ?: $this->getConfig('errorStyle');
         $custom = $options['custom'];
         $inline = $options['inline'];
         $nestedInput = $options['nestedInput'];

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -15,6 +15,62 @@ class FormHelper extends Helper
     use OptionsAwareTrait;
 
     /**
+     * The default error style.
+     *
+     * @var string
+     */
+    public const ERROR_STYLE_DEFAULT = 'default';
+
+    /**
+     * The none error style.
+     *
+     * @var string
+     */
+    public const ERROR_STYLE_NONE = 'none';
+
+    /**
+     * The tooltip error style.
+     *
+     * @var string
+     */
+    public const ERROR_STYLE_TOOLTIP = 'tooltip';
+
+    /**
+     * Absolute positioning.
+     *
+     * @var string
+     */
+    public const POSITION_ABSOLUTE = 'absolute';
+
+    /**
+     * Fixed positioning.
+     *
+     * @var string
+     */
+    public const POSITION_FIXED = 'fixed';
+
+    /**
+     * Relative positioning.
+     *
+     * @var string
+     */
+    public const POSITION_RELATIVE = 'relative';
+
+    /**
+     * Static positioning.
+     *
+     * @var string
+     */
+    public const POSITION_STATIC = 'static';
+
+    /**
+     * Sticky positioning.
+     *
+     * @var string
+     */
+    public const POSITION_STICKY = 'sticky';
+
+    /**
      * Set on `Form::create()` to tell if the type of alignment used (i.e. horizontal).
      *
      * @var string|null
@@ -35,32 +91,38 @@ class FormHelper extends Helper
      */
     protected $_templates = [
         'error' => '<div class="invalid-feedback">{{content}}</div>',
+        'errorTooltip' => '<div class="invalid-tooltip">{{content}}</div>',
         'label' => '<label{{attrs}}>{{text}}{{tooltip}}</label>',
         'help' => '<small{{attrs}} class="form-text text-muted">{{content}}</small>',
         'tooltip' => '<span data-toggle="tooltip" title="{{content}}" class="fas fa-info-circle"></span>',
         'datetimeContainer' => '<div class="form-group {{type}}{{required}}" role="group" ' .
                 'aria-labelledby="{{groupId}}">{{content}}{{help}}</div>',
-        'datetimeContainerError' => '<div class="form-group {{type}}{{required}} is-invalid" ' .
+        'datetimeContainerError' =>
+            '<div class="form-group {{formGroupPosition}}{{type}}{{required}} is-invalid" ' .
                 'role="group" aria-labelledby="{{groupId}}">{{content}}{{error}}{{help}}</div>',
         'datetimeLabel' => '<label id="{{groupId}}">{{text}}{{tooltip}}</label>',
         'inputContainer' => '<div class="form-group {{type}}{{required}}">{{content}}{{help}}</div>',
-        'inputContainerError' => '<div class="form-group {{type}}{{required}} is-invalid">' .
+        'inputContainerError' =>
+            '<div class="form-group {{formGroupPosition}}{{type}}{{required}} is-invalid">' .
                 '{{content}}{{error}}{{help}}</div>',
         'checkboxContainer' => '<div class="form-group form-check {{type}}{{required}}">{{content}}{{help}}</div>',
-        'checkboxContainerError' => '<div class="form-group form-check {{type}}{{required}} is-invalid">' .
+        'checkboxContainerError' =>
+            '<div class="form-group form-check {{formGroupPosition}}{{type}}{{required}} is-invalid">' .
                 '{{content}}{{error}}{{help}}</div>',
         'customCheckboxContainer' => '<div class="form-group custom-control custom-checkbox ' .
                 '{{type}}{{required}}">{{content}}{{help}}</div>',
-        'customCheckboxContainerError' => '<div class="form-group custom-control custom-checkbox ' .
-                '{{type}}{{required}} is-invalid">{{content}}{{error}}{{help}}</div>',
+        'customCheckboxContainerError' =>
+            '<div class="form-group custom-control custom-checkbox ' .
+                '{{formGroupPosition}}{{type}}{{required}} is-invalid">{{content}}{{error}}{{help}}</div>',
         'checkboxInlineContainer' => '<div class="form-check form-check-inline {{type}}{{required}}">' .
                 '{{content}}</div>',
         'checkboxInlineContainerError' => '<div class="form-check form-check-inline {{type}}{{required}} ' .
                 'is-invalid">{{content}}</div>',
         'customCheckboxInlineContainer' => '<div class="form-group custom-control custom-checkbox ' .
                 'custom-control-inline {{type}}{{required}}">{{content}}</div>',
-        'customCheckboxInlineContainerError' => '<div class="form-group custom-control custom-checkbox ' .
-                'custom-control-inline {{type}}{{required}} is-invalid">{{content}}</div>',
+        'customCheckboxInlineContainerError' =>
+            '<div class="form-group custom-control custom-checkbox custom-control-inline ' .
+                '{{formGroupPosition}}{{type}}{{required}} is-invalid">{{content}}</div>',
         'checkboxFormGroup' => '{{input}}{{label}}',
         'checkboxWrapper' => '<div class="form-check">{{label}}</div>',
         'checkboxInlineWrapper' => '<div class="form-check form-check-inline">{{label}}</div>',
@@ -69,7 +131,8 @@ class FormHelper extends Helper
                 '{{label}}</div>',
         'radioContainer' => '<div class="form-group {{type}}{{required}}" role="group" ' .
                 'aria-labelledby="{{groupId}}">{{content}}{{help}}</div>',
-        'radioContainerError' => '<div class="form-group {{type}}{{required}} is-invalid" role="group" ' .
+        'radioContainerError' =>
+            '<div class="form-group {{formGroupPosition}}{{type}}{{required}} is-invalid" role="group" ' .
                 'aria-labelledby="{{groupId}}">{{content}}{{error}}{{help}}</div>',
         'radioLabel' => '<label id="{{groupId}}" class="d-block">{{text}}{{tooltip}}</label>',
         'radioWrapper' => '<div class="form-check">{{hidden}}{{label}}</div>',
@@ -83,7 +146,8 @@ class FormHelper extends Helper
         'inputGroupText' => '<span class="input-group-text">{{content}}</span>',
         'multicheckboxContainer' => '<div class="form-group {{type}}{{required}}" role="group" ' .
                 'aria-labelledby="{{groupId}}">{{content}}{{help}}</div>',
-        'multicheckboxContainerError' => '<div class="form-group {{type}}{{required}} is-invalid" role="group" ' .
+        'multicheckboxContainerError' =>
+            '<div class="form-group {{formGroupPosition}}{{type}}{{required}} is-invalid" role="group" ' .
                 'aria-labelledby="{{groupId}}">{{content}}{{error}}{{help}}</div>',
         'multicheckboxLabel' => '<label id="{{groupId}}" class="d-block">{{text}}{{tooltip}}</label>',
         'multicheckboxWrapper' => '<fieldset class="form-group">{{content}}</fieldset>',
@@ -107,20 +171,32 @@ class FormHelper extends Helper
         ],
         'inline' => [
             'label' => '<label class="sr-only"{{attrs}}>{{text}}{{tooltip}}</label>',
-            'datetimeContainer' => '<div class="form-group {{type}}{{required}}" role="group" ' .
+            'checkboxInlineContainerError' =>
+                '<div class="form-check form-check-inline {{formGroupPosition}}{{type}}{{required}} ' .
+                    'is-invalid">{{content}}{{error}}</div>',
+            'customCheckboxInlineContainerError' =>
+                '<div class="form-group custom-control custom-checkbox custom-control-inline ' .
+                    '{{formGroupPosition}}{{type}}{{required}} is-invalid">{{content}}{{error}}</div>',
+            'datetimeContainer' =>
+                '<div class="form-group {{formGroupPosition}}{{type}}{{required}}" role="group" ' .
                     'aria-labelledby="{{groupId}}">{{content}}</div>',
-            'datetimeContainerError' => '<div class="form-group {{type}}{{required}} is-invalid" ' .
-                    'role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
+            'datetimeContainerError' =>
+                '<div class="form-group {{formGroupPosition}}{{type}}{{required}} is-invalid" ' .
+                    'role="group" aria-labelledby="{{groupId}}">{{content}}{{error}}</div>',
             'datetimeLabel' => '<span id="{{groupId}}" class="sr-only">{{text}}{{tooltip}}</span>',
-            'radioContainer' => '<div class="form-group {{type}}{{required}}" role="group" ' .
+            'radioContainer' =>
+                '<div class="form-group {{formGroupPosition}}{{type}}{{required}}" role="group" ' .
                     'aria-labelledby="{{groupId}}">{{content}}</div>',
-            'radioContainerError' => '<div class="form-group {{type}}{{required}} is-invalid" ' .
-                    'role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
+            'radioContainerError' =>
+                '<div class="form-group {{formGroupPosition}}{{type}}{{required}} is-invalid" ' .
+                    'role="group" aria-labelledby="{{groupId}}">{{content}}{{error}}</div>',
             'radioLabel' => '<span id="{{groupId}}" class="sr-only">{{text}}{{tooltip}}</span>',
-            'multicheckboxContainer' => '<div class="form-group {{type}}{{required}}" role="group" ' .
+            'multicheckboxContainer' =>
+                '<div class="form-group {{formGroupPosition}}{{type}}{{required}}" role="group" ' .
                     'aria-labelledby="{{groupId}}">{{content}}</div>',
-            'multicheckboxContainerError' => '<div class="form-group {{type}}{{required}} is-invalid" ' .
-                    'role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
+            'multicheckboxContainerError' =>
+                '<div class="form-group {{formGroupPosition}}{{type}}{{required}} is-invalid" ' .
+                    'role="group" aria-labelledby="{{groupId}}">{{content}}{{error}}</div>',
             'multicheckboxLabel' => '<span id="{{groupId}}" class="sr-only">{{text}}{{tooltip}}</span>',
         ],
         'horizontal' => [
@@ -136,27 +212,30 @@ class FormHelper extends Helper
                     '{{input}}{{label}}{{error}}{{help}}</div></div>',
             'datetimeContainer' => '<div class="form-group row {{type}}{{required}}" role="group" ' .
                     'aria-labelledby="{{groupId}}">{{content}}</div>',
-            'datetimeContainerError' => '<div class="form-group row {{type}}{{required}} is-invalid" ' .
+            'datetimeContainerError' =>
+                '<div class="form-group row {{formGroupPosition}}{{type}}{{required}} is-invalid" ' .
                     'role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
             'datetimeLabel' => '<label id="{{groupId}}" class="col-form-label %s">{{text}}{{tooltip}}</label>',
             'checkboxInlineFormGroup' => '<div class="%s"><div class="form-check form-check-inline">' .
                     '{{input}}{{label}}</div></div>',
             'submitContainer' => '<div class="form-group row"><div class="%s">{{content}}</div></div>',
             'inputContainer' => '<div class="form-group row {{type}}{{required}}">{{content}}</div>',
-            'inputContainerError' => '<div class="form-group row {{type}}{{required}} ' .
-                    'is-invalid">{{content}}</div>',
+            'inputContainerError' =>
+                '<div class="form-group row {{formGroupPosition}}{{type}}{{required}} is-invalid">{{content}}</div>',
             'checkboxContainer' => '<div class="form-group row {{type}}{{required}}">{{content}}</div>',
-            'checkboxContainerError' => '<div class="form-group row {{type}}{{required}} ' .
-                    'is-invalid">{{content}}</div>',
+            'checkboxContainerError' =>
+                '<div class="form-group row {{formGroupPosition}}{{type}}{{required}} is-invalid">{{content}}</div>',
             'radioContainer' => '<div class="form-group row {{type}}{{required}}" role="group" ' .
                     'aria-labelledby="{{groupId}}">{{content}}</div>',
-            'radioContainerError' => '<div class="form-group row {{type}}{{required}} is-invalid" ' .
+            'radioContainerError' =>
+                '<div class="form-group row {{formGroupPosition}}{{type}}{{required}} is-invalid" ' .
                     'role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
             'radioLabel' =>
                 '<label id="{{groupId}}" class="col-form-label d-block pt-0 %s">{{text}}{{tooltip}}</label>',
             'multicheckboxContainer' => '<div class="form-group row {{type}}{{required}}" role="group" ' .
                     'aria-labelledby="{{groupId}}">{{content}}</div>',
-            'multicheckboxContainerError' => '<div class="form-group row {{type}}{{required}} is-invalid" ' .
+            'multicheckboxContainerError' =>
+                '<div class="form-group row {{formGroupPosition}}{{type}}{{required}} is-invalid" ' .
                     'role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
             'multicheckboxLabel' =>
                 '<label id="{{groupId}}" class="col-form-label d-block pt-0 %s">{{text}}{{tooltip}}</label>',
@@ -279,6 +358,8 @@ class FormHelper extends Helper
     public function control(string $fieldName, array $options = []): string
     {
         $options += [
+            'errorStyle' => null,
+            'formGroupPosition' => null,
             'custom' => false,
             'prepend' => null,
             'append' => null,
@@ -297,10 +378,18 @@ class FormHelper extends Helper
         ];
         $options = $this->_parseOptions($fieldName, $options);
 
+        $formGroupPosition = $options['formGroupPosition'];
+        $errorStyle = $options['errorStyle'];
         $custom = $options['custom'];
         $inline = $options['inline'];
         $nestedInput = $options['nestedInput'];
-        unset($options['custom'], $options['inline'], $options['nestedInput']);
+        unset(
+            $options['formGroupPosition'],
+            $options['errorStyle'],
+            $options['custom'],
+            $options['inline'],
+            $options['nestedInput']
+        );
 
         $newTemplates = $options['templates'];
         if ($newTemplates) {
@@ -488,6 +577,34 @@ class FormHelper extends Helper
                     $options = $this->injectClasses('custom-range', $options);
                 }
                 break;
+        }
+
+        if (
+            $this->_align === 'inline' &&
+            $errorStyle === null
+        ) {
+            $errorStyle = static::ERROR_STYLE_TOOLTIP;
+        }
+
+        switch ($errorStyle) {
+            case static::ERROR_STYLE_NONE:
+                $options['templates']['error'] = '';
+                break;
+
+            case static::ERROR_STYLE_TOOLTIP:
+                $options['templates']['error'] = $this->templater()->get('errorTooltip');
+                break;
+        }
+
+        if (
+            $formGroupPosition === null &&
+            $errorStyle === static::ERROR_STYLE_TOOLTIP
+        ) {
+            $formGroupPosition = static::POSITION_RELATIVE;
+        }
+
+        if ($formGroupPosition !== null) {
+            $options['templateVars']['formGroupPosition'] = 'position-' . $formGroupPosition . ' ';
         }
 
         if ($options['help']) {

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -587,14 +587,8 @@ class FormHelper extends Helper
             $errorStyle = static::ERROR_STYLE_TOOLTIP;
         }
 
-        switch ($errorStyle) {
-            case static::ERROR_STYLE_NONE:
-                $options['templates']['error'] = '';
-                break;
-
-            case static::ERROR_STYLE_TOOLTIP:
-                $options['templates']['error'] = $this->templater()->get('errorTooltip');
-                break;
+        if ($errorStyle === static::ERROR_STYLE_TOOLTIP) {
+            $options['templates']['error'] = $this->templater()->get('errorTooltip');
         }
 
         if (

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -171,6 +171,7 @@ class FormHelper extends Helper
         ],
         'inline' => [
             'label' => '<label class="sr-only"{{attrs}}>{{text}}{{tooltip}}</label>',
+            'help' => '<small{{attrs}} class="sr-only form-text text-muted">{{content}}</small>',
             'checkboxInlineContainerError' =>
                 '<div class="form-check form-check-inline {{formGroupPosition}}{{type}}{{required}} ' .
                     'is-invalid">{{content}}{{error}}</div>',

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -350,7 +350,11 @@ class FormHelper extends Helper
      * - `append` - Append addon to input.
      * - `prepend` - Prepend addon to input.
      * - `inline` - Boolean for generating inline checkbox/radio.
-     * - `help` - Help text of include in the input container.
+     * - `help` - Help text to include in the input container.
+     * - `tooltip` - Tooltip text to include in the control's label.
+     * - `errorStyle` - The error style to use, `default`, or `tooltip` (will cause `formGroupPosition` to be set to
+     *  `relative` unless explicitly configured otherwise).
+     * - `formGroupPosition` - CSS positioning of form groups, `absolute`, `fixed`, `relative`, `static`, or `sticky`.
      *
      * @param string $fieldName This should be "Modelname.fieldname".
      * @param array $options Each type of input takes different options.

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2300,7 +2300,7 @@ class FormHelperTest extends TestCase
             'value' => $now->format('Y-m-d H:i:s'),
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group datetime-local', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
+            ['div' => ['class' => 'form-group position-relative datetime-local', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
                 ['span' => ['id' => 'created-group-label', 'class' => 'sr-only']],
                     'Created',
                 '/span',
@@ -2332,7 +2332,7 @@ class FormHelperTest extends TestCase
             'tooltip' => 'Tooltip text',
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group datetime-local', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
+            ['div' => ['class' => 'form-group position-relative datetime-local', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
                 ['span' => ['id' => 'created-group-label', 'class' => 'sr-only']],
                     'Created ',
                     'span' => [
@@ -2376,7 +2376,7 @@ class FormHelperTest extends TestCase
         ]);
         $expected = [
             ['div' => [
-                'class' => 'form-group datetime-local is-invalid',
+                'class' => 'form-group position-relative datetime-local is-invalid',
                 'role' => 'group',
                 'aria-labelledby' => 'created-group-label',
             ]],
@@ -2390,6 +2390,9 @@ class FormHelperTest extends TestCase
                     'class' => 'is-invalid form-control',
                     'value' => $now->format('Y-m-d H:i:s'),
                 ],
+                ['div' => ['class' => 'invalid-tooltip']],
+                    'error message',
+                '/div',
             '/div',
         ];
         $this->assertHtml($expected, $result);
@@ -2410,7 +2413,7 @@ class FormHelperTest extends TestCase
             'value' => $now,
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group date', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
+            ['div' => ['class' => 'form-group position-relative date', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
                 ['span' => ['id' => 'created-group-label', 'class' => 'sr-only']],
                     'Created',
                 '/span',
@@ -2441,7 +2444,7 @@ class FormHelperTest extends TestCase
             'value' => $now,
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group time', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
+            ['div' => ['class' => 'form-group position-relative time', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
                 ['span' => ['id' => 'created-group-label', 'class' => 'sr-only']],
                     'Created',
                 '/span',
@@ -2469,17 +2472,17 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('created', [
             'type' => 'datetime',
         ]);
-        $this->assertStringContainsString('<div class="form-group datetime" role="group" aria-labelledby="created-group-label">', $result);
+        $this->assertStringContainsString('<div class="form-group position-relative datetime" role="group" aria-labelledby="created-group-label">', $result);
 
         $result = $this->Form->control('created', [
             'type' => 'date',
         ]);
-        $this->assertStringContainsString('<div class="form-group date" role="group" aria-labelledby="created-group-label">', $result);
+        $this->assertStringContainsString('<div class="form-group position-relative date" role="group" aria-labelledby="created-group-label">', $result);
 
         $result = $this->Form->control('created', [
             'type' => 'time',
         ]);
-        $this->assertStringContainsString('<div class="form-group time" role="group" aria-labelledby="created-group-label">', $result);
+        $this->assertStringContainsString('<div class="form-group position-relative time" role="group" aria-labelledby="created-group-label">', $result);
 
         $this->Form->setTemplates([
             'datetimeContainer' => '<div class="custom datetimeContainer {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
@@ -2518,17 +2521,17 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('created', [
             'type' => 'datetime',
         ]);
-        $this->assertStringContainsString('<div class="form-group datetime is-invalid" role="group" aria-labelledby="created-group-label">', $result);
+        $this->assertStringContainsString('<div class="form-group position-relative datetime is-invalid" role="group" aria-labelledby="created-group-label">', $result);
 
         $result = $this->Form->control('created', [
             'type' => 'date',
         ]);
-        $this->assertStringContainsString('<div class="form-group date is-invalid" role="group" aria-labelledby="created-group-label">', $result);
+        $this->assertStringContainsString('<div class="form-group position-relative date is-invalid" role="group" aria-labelledby="created-group-label">', $result);
 
         $result = $this->Form->control('created', [
             'type' => 'time',
         ]);
-        $this->assertStringContainsString('<div class="form-group time is-invalid" role="group" aria-labelledby="created-group-label">', $result);
+        $this->assertStringContainsString('<div class="form-group position-relative time is-invalid" role="group" aria-labelledby="created-group-label">', $result);
 
         $result = $this->Form->control('created', [
             'type' => 'datetime',
@@ -3523,7 +3526,7 @@ class FormHelperTest extends TestCase
             'type' => 'checkbox',
         ]);
         $expected = [
-            ['div' => ['class' => 'form-check form-check-inline checkbox is-invalid']],
+            ['div' => ['class' => 'form-check form-check-inline position-relative checkbox is-invalid']],
                 ['input' => [
                     'class' => 'is-invalid',
                     'type' => 'hidden',
@@ -3540,6 +3543,9 @@ class FormHelperTest extends TestCase
                 ['label' => ['class' => 'form-check-label', 'for' => 'users']],
                     'Users',
                 '/label',
+                ['div' => ['class' => 'invalid-tooltip']],
+                    'error message',
+                '/div',
             '/div',
         ];
         $this->assertHtml($expected, $result);
@@ -5222,7 +5228,7 @@ class FormHelperTest extends TestCase
             ],
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group radio', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+            ['div' => ['class' => 'form-group position-relative radio', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
                 ['span' => ['id' => 'users-group-label', 'class' => 'sr-only']],
                     'Users',
                 '/span',
@@ -5312,7 +5318,7 @@ class FormHelperTest extends TestCase
             ],
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group radio is-invalid', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+            ['div' => ['class' => 'form-group position-relative radio is-invalid', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
                 ['span' => ['id' => 'users-group-label', 'class' => 'sr-only']],
                     'Users',
                 '/span',
@@ -5346,6 +5352,9 @@ class FormHelperTest extends TestCase
                         'option 2',
                     '/label',
                 '/div',
+                ['div' => ['class' => 'invalid-tooltip']],
+                    'error message',
+                '/div',
             '/div',
         ];
         $this->assertHtml($expected, $result);
@@ -5375,7 +5384,7 @@ class FormHelperTest extends TestCase
             ],
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group radio', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+            ['div' => ['class' => 'form-group position-relative radio', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
                 ['span' => ['id' => 'users-group-label', 'class' => 'sr-only']],
                     'Users',
                 '/span',
@@ -5442,7 +5451,7 @@ class FormHelperTest extends TestCase
             'nestedInput' => true,
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group radio', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+            ['div' => ['class' => 'form-group position-relative radio', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
                 ['span' => ['id' => 'users-group-label', 'class' => 'sr-only']],
                     'Users',
                 '/span',
@@ -5505,7 +5514,7 @@ class FormHelperTest extends TestCase
             'nestedInput' => true,
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group radio', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+            ['div' => ['class' => 'form-group position-relative radio', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
                 ['span' => ['id' => 'users-group-label', 'class' => 'sr-only']],
                     'Users',
                 '/span',
@@ -8388,7 +8397,7 @@ class FormHelperTest extends TestCase
             ],
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+            ['div' => ['class' => 'form-group position-relative multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
                 ['span' => ['id' => 'users-group-label', 'class' => 'sr-only']],
                     'Users',
                 '/span',
@@ -8440,7 +8449,7 @@ class FormHelperTest extends TestCase
             'tooltip' => 'Tooltip text',
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+            ['div' => ['class' => 'form-group position-relative multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
                 ['span' => ['id' => 'users-group-label', 'class' => 'sr-only']],
                     'Users ',
                     'span' => [
@@ -8483,7 +8492,7 @@ class FormHelperTest extends TestCase
         ]);
         $expected = [
             ['div' => [
-                'class' => 'form-group multicheckbox is-invalid',
+                'class' => 'form-group position-relative multicheckbox is-invalid',
                 'role' => 'group',
                 'aria-labelledby' => 'users-group-label',
             ]],
@@ -8520,6 +8529,9 @@ class FormHelperTest extends TestCase
                         'option 2',
                     '/label',
                 '/div',
+                ['div' => ['class' => 'invalid-tooltip']],
+                    'error message',
+                '/div',
             '/div',
         ];
         $this->assertHtml($expected, $result);
@@ -8549,7 +8561,7 @@ class FormHelperTest extends TestCase
             ],
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+            ['div' => ['class' => 'form-group position-relative multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
                 ['span' => ['id' => 'users-group-label', 'class' => 'sr-only']],
                     'Users',
                 '/span',
@@ -8616,7 +8628,7 @@ class FormHelperTest extends TestCase
             'nestedInput' => true,
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+            ['div' => ['class' => 'form-group position-relative multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
                 ['span' => ['id' => 'users-group-label', 'class' => 'sr-only']],
                     'Users',
                 '/span',
@@ -8679,7 +8691,7 @@ class FormHelperTest extends TestCase
             'nestedInput' => true,
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+            ['div' => ['class' => 'form-group position-relative multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
                 ['span' => ['id' => 'users-group-label', 'class' => 'sr-only']],
                     'Users',
                 '/span',
@@ -8996,7 +9008,7 @@ class FormHelperTest extends TestCase
             'type' => 'file',
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group file is-invalid']],
+            ['div' => ['class' => 'form-group position-relative file is-invalid']],
                 ['label' => ['class' => 'sr-only', 'for' => 'file']],
                     'File',
                 '/label',
@@ -9006,7 +9018,7 @@ class FormHelperTest extends TestCase
                     'id' => 'file',
                     'class' => 'is-invalid form-control-file',
                 ]],
-                ['div' => ['class' => 'invalid-feedback']],
+                ['div' => ['class' => 'invalid-tooltip']],
                     'error message',
                 '/div',
             '/div',
@@ -9326,7 +9338,7 @@ class FormHelperTest extends TestCase
             'step' => 1,
         ]);
         $expected = [
-            'div' => ['class' => 'form-group range is-invalid'],
+            'div' => ['class' => 'form-group position-relative range is-invalid'],
                 ['label' => ['class' => 'sr-only', 'for' => 'height']],
                     'Height',
                 '/label',
@@ -9339,9 +9351,9 @@ class FormHelperTest extends TestCase
                     'id' => 'height',
                     'class' => 'is-invalid form-control',
                 ],
-                    ['div' => ['class' => 'invalid-feedback']],
-                        'error message',
-                    '/div',
+                ['div' => ['class' => 'invalid-tooltip']],
+                    'error message',
+                '/div',
             '/div',
         ];
         $this->assertHtml($expected, $result);
@@ -10165,7 +10177,7 @@ class FormHelperTest extends TestCase
             'custom' => true,
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group radio', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+            ['div' => ['class' => 'form-group position-relative radio', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
                 ['span' => ['id' => 'users-group-label', 'class' => 'sr-only']],
                     'Users',
                 '/span',
@@ -10228,7 +10240,7 @@ class FormHelperTest extends TestCase
             'custom' => true,
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group radio', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+            ['div' => ['class' => 'form-group position-relative radio', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
                 ['span' => ['id' => 'users-group-label', 'class' => 'sr-only']],
                     'Users',
                 '/span',
@@ -11343,7 +11355,7 @@ class FormHelperTest extends TestCase
             'custom' => true,
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+            ['div' => ['class' => 'form-group position-relative multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
                 ['span' => ['id' => 'users-group-label', 'class' => 'sr-only']],
                     'Users',
                 '/span',
@@ -11406,7 +11418,7 @@ class FormHelperTest extends TestCase
             'custom' => true,
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+            ['div' => ['class' => 'form-group position-relative multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
                 ['span' => ['id' => 'users-group-label', 'class' => 'sr-only']],
                     'Users',
                 '/span',
@@ -11655,7 +11667,7 @@ class FormHelperTest extends TestCase
             'custom' => true,
         ]);
         $expected = [
-            'div' => ['class' => 'form-group range is-invalid'],
+            'div' => ['class' => 'form-group position-relative range is-invalid'],
                 ['label' => ['class' => 'sr-only', 'for' => 'height']],
                     'Height',
                 '/label',
@@ -11668,7 +11680,7 @@ class FormHelperTest extends TestCase
                     'id' => 'height',
                     'class' => 'custom-range is-invalid',
                 ],
-                ['div' => ['class' => 'invalid-feedback']],
+                ['div' => ['class' => 'invalid-tooltip']],
                     'error message',
                 '/div',
             '/div',
@@ -12486,7 +12498,7 @@ class FormHelperTest extends TestCase
             'custom' => true,
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group file is-invalid']],
+            ['div' => ['class' => 'form-group position-relative file is-invalid']],
                 ['div' => ['class' => 'custom-file is-invalid']],
                     ['input' => [
                         'type' => 'file',
@@ -12498,7 +12510,7 @@ class FormHelperTest extends TestCase
                         'File',
                     '/label',
                 '/div',
-                ['div' => ['class' => 'invalid-feedback']],
+                ['div' => ['class' => 'invalid-tooltip']],
                     'error message',
                 '/div',
             '/div',
@@ -12599,7 +12611,7 @@ class FormHelperTest extends TestCase
             'append' => 'append',
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group file is-invalid']],
+            ['div' => ['class' => 'form-group position-relative file is-invalid']],
                 ['div' => ['class' => 'input-group is-invalid']],
                     ['div' => ['class' => 'custom-file is-invalid']],
                         ['input' => [
@@ -12618,7 +12630,7 @@ class FormHelperTest extends TestCase
                         '/span',
                     '/div',
                 '/div',
-                ['div' => ['class' => 'invalid-feedback']],
+                ['div' => ['class' => 'invalid-tooltip']],
                     'error message',
                 '/div',
             '/div',

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -1738,6 +1738,113 @@ class FormHelperTest extends TestCase
         $this->Form->create($this->article, ['align' => 'foo']);
     }
 
+    public function testDefaultAlignControlWithTooltipErrorStyle()
+    {
+        $this->article['errors'] = [
+            'title' => ['error message'],
+        ];
+        $this->article['required']['title'] = false;
+
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('title', [
+            'errorStyle' => FormHelper::ERROR_STYLE_TOOLTIP,
+        ]);
+
+        $expected = [
+            ['div' => ['class' => 'form-group position-relative text is-invalid']],
+                ['label' => ['for' => 'title']],
+                    'Title',
+                '/label',
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'title',
+                    'id' => 'title',
+                    'class' => 'is-invalid form-control',
+                ],
+                ['div' => ['class' => 'invalid-tooltip']],
+                    'error message',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testInlineAlignControlWithDefaultErrorStyle()
+    {
+        $this->article['errors'] = [
+            'title' => ['error message'],
+        ];
+        $this->article['required']['title'] = false;
+
+        $this->Form->create($this->article, [
+            'align' => 'inline',
+        ]);
+
+        $result = $this->Form->control('title', [
+            'errorStyle' => FormHelper::ERROR_STYLE_DEFAULT,
+        ]);
+
+        $expected = [
+            ['div' => ['class' => 'form-group text is-invalid']],
+                ['label' => ['class' => 'sr-only', 'for' => 'title']],
+                    'Title',
+                '/label',
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'title',
+                    'id' => 'title',
+                    'class' => 'is-invalid form-control',
+                ],
+                ['div' => ['class' => 'invalid-feedback']],
+                    'error message',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignControlWithTooltipErrorStyle()
+    {
+        $this->article['errors'] = [
+            'title' => ['error message'],
+        ];
+        $this->article['required']['title'] = false;
+
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('title', [
+            'errorStyle' => FormHelper::ERROR_STYLE_TOOLTIP,
+        ]);
+
+        $expected = [
+            ['div' => ['class' => 'form-group row position-relative text is-invalid']],
+                ['label' => ['class' => 'col-form-label col-sm-5', 'for' => 'title']],
+                    'Title',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    ['input' => [
+                        'type' => 'text',
+                        'name' => 'title',
+                        'id' => 'title',
+                        'class' => 'is-invalid form-control',
+                    ]],
+                    ['div' => ['class' => 'invalid-tooltip']],
+                        'error message',
+                    '/div',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testDefaultAlignDatetimeControl()
     {
         $this->Form->create($this->article);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -1738,6 +1738,140 @@ class FormHelperTest extends TestCase
         $this->Form->create($this->article, ['align' => 'foo']);
     }
 
+    public function testErrorStyleFromHelperConfig()
+    {
+        $this->article['errors'] = [
+            'title' => ['error message'],
+        ];
+        $this->article['required']['title'] = false;
+
+        $this->Form->setConfig('errorStyle', FormHelper::ERROR_STYLE_TOOLTIP);
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('title');
+
+        $expected = [
+            ['div' => ['class' => 'form-group position-relative text is-invalid']],
+                ['label' => ['for' => 'title']],
+                    'Title',
+                '/label',
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'title',
+                    'id' => 'title',
+                    'class' => 'is-invalid form-control',
+                ],
+                ['div' => ['class' => 'invalid-tooltip']],
+                    'error message',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testOverrideErrorStyleFromHelperConfigViaControlConfig()
+    {
+        $this->article['errors'] = [
+            'title' => ['error message'],
+        ];
+        $this->article['required']['title'] = false;
+
+        $this->Form->setConfig('errorStyle', FormHelper::ERROR_STYLE_TOOLTIP);
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('title', [
+            'errorStyle' => FormHelper::ERROR_STYLE_DEFAULT,
+        ]);
+
+        $expected = [
+            ['div' => ['class' => 'form-group text is-invalid']],
+                ['label' => ['for' => 'title']],
+                    'Title',
+                '/label',
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'title',
+                    'id' => 'title',
+                    'class' => 'is-invalid form-control',
+                ],
+                ['div' => ['class' => 'invalid-feedback']],
+                    'error message',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testFormGroupPositionFromHelperConfig()
+    {
+        $this->article['errors'] = [
+            'title' => ['error message'],
+        ];
+        $this->article['required']['title'] = false;
+
+        $this->Form->setConfig([
+            'errorStyle' => FormHelper::ERROR_STYLE_TOOLTIP,
+            'formGroupPosition' => FormHelper::POSITION_ABSOLUTE,
+        ]);
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('title');
+
+        $expected = [
+            ['div' => ['class' => 'form-group position-absolute text is-invalid']],
+                ['label' => ['for' => 'title']],
+                    'Title',
+                '/label',
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'title',
+                    'id' => 'title',
+                    'class' => 'is-invalid form-control',
+                ],
+                ['div' => ['class' => 'invalid-tooltip']],
+                    'error message',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testOverrideFormGroupPositionFromHelperConfigViaControlConfig()
+    {
+        $this->article['errors'] = [
+            'title' => ['error message'],
+        ];
+        $this->article['required']['title'] = false;
+
+        $this->Form->setConfig([
+            'errorStyle' => FormHelper::ERROR_STYLE_TOOLTIP,
+            'formGroupPosition' => FormHelper::POSITION_ABSOLUTE,
+        ]);
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('title', [
+            'formGroupPosition' => FormHelper::POSITION_STATIC,
+        ]);
+
+        $expected = [
+            ['div' => ['class' => 'form-group position-static text is-invalid']],
+                ['label' => ['for' => 'title']],
+                    'Title',
+                '/label',
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'title',
+                    'id' => 'title',
+                    'class' => 'is-invalid form-control',
+                ],
+                ['div' => ['class' => 'invalid-tooltip']],
+                    'error message',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testDefaultAlignControlWithTooltipErrorStyle()
     {
         $this->article['errors'] = [


### PR DESCRIPTION
This PR adds general support for error [**feedback as tooltips**](https://getbootstrap.com/docs/4.5/components/forms/#tooltips), and makes help text in [**inline aligned forms**](https://getbootstrap.com/docs/4.5/components/forms/#inline-forms) screen-reader only. 

I'll clean it up and add/fix tests once there is a consensus on whether this change makes sense, and depending on whether the approach needs to be changed.

Here's how tooltip feedback generally looks (yes, that overlap is expected, and will appear the same with "vanilla" Bootstrap markup):

![error-feedback-default-controls-tooltip](https://user-images.githubusercontent.com/5031606/83356854-13f5f080-a369-11ea-81bc-3b9d766a5342.png)

## Tooltip feedback as default for inline forms

Currently error message feedback in inline aligned forms isn't unified, it looks kinda messy and can break the layout, hence this PR makes error tooltips the default for inline align. Making help text screen-reader only compliments this, as help text messes the layout up too.

IMHO this makes inline controls pretty much complete, and RC ready.

Here's a before/after for some of the inline controls:

![inline-controls-before-after](https://user-images.githubusercontent.com/5031606/83356893-5fa89a00-a369-11ea-8602-e32fc8730bed.png)

The width of the tooltip is bound to the width of the parent element, so people would need to style their forms accordingly, but that's just how the default Bootstrap CSS works.

## Non-static positioning required

One problem with feedback tooltips is that they won't be displayed properly unless the parent element is `relative`, `absolute`, `fixed` or `sticky` positioned, which is simply because the tooltips are using `absolute` positioning with a `top` value of `100%`, which can lead to the tooltip being rendered misplaced, or even completely outside of the viewport.

Quote from [**the Bootstrap feedback tooltip docs**](https://getbootstrap.com/docs/4.5/components/forms/#tooltips):

> [...] Be sure to have a parent with `position: relative` on it for tooltip positioning [...]

I've chosen to handle this by introducing a configurable template variable that translates to one of Bootstraps [**`position-*` utility classes**](https://getbootstrap.com/docs/4.5/utilities/position/). The `formGroupPosition` option (there might be a better name for this) defaults to `relative` (if omitted), and can be configured according to one's needs.

There's probably other ways to solve this, for example simply doing nothing, and requiring people to add CSS rules for `.form-group` according to their needs - probably a reasonable requirement, but the downside would of course be that things wouldn't work ouf of the box.

## Doesn't work well with help text

One more problem is the combination with help text, which will change the height of the containing element, causing the feedback tooltip to be placed underneath the help text, which can look odd. There's not really much that could be done about it, people would need to either not use help text (they could use label tooltips instead), or use custom CSS for the feedback tooltips to position them according to their preference. Here's what it looks like with help text vs without:

![error-feedback-tooltips-help-text-compare](https://user-images.githubusercontent.com/5031606/83356826-e27d2500-a368-11ea-94d9-a80f3c398220.png)