### PR TITLE
Rename `errorStyle` to `feedbackStyle`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,12 +463,13 @@ BootstrapUI supports two styles of error feedback, the
 [Bootstrap tooltip feedback](https://getbootstrap.com/docs/4.5/components/forms/#tooltips) (not to be confused with
 label tooltips that are configured via the `tooltip` option!).
 
-The style can be configured via the `errorStyle` option, either globally, per form, or per control. The supported styles
-are:
+The style can be configured via the `feedbackStyle` option, either globally, per form, or per control. The supported
+styles are:
 
-- `\BootstrapUI\View\Helper\FormHelper::ERROR_STYLE_DEFAULT` Render error feedback as regular Bootstrap text feedback.
-- `\BootstrapUI\View\Helper\FormHelper::ERROR_STYLE_TOOLTIP` Render error feedback as Bootstrap tooltip feedback (inline
- forms are using this style by default).
+- `\BootstrapUI\View\Helper\FormHelper::FEEDBACK_STYLE_DEFAULT` Render error feedback as regular Bootstrap text
+ feedback.
+- `\BootstrapUI\View\Helper\FormHelper::FEEDBACK_STYLE_TOOLTIP` Render error feedback as Bootstrap tooltip feedback
+ (inline forms are using this style by default).
 
 Note that using the tooltip error style requires the form group elements to be non-static positioned! The form helper
 will automatically add Bootstraps [position utility class](https://getbootstrap.com/docs/4.5/utilities/position/)
@@ -486,7 +487,7 @@ supports the following values:
 
 ```php
 $this->Form->setConfig([
-    'errorStyle' => \BootstrapUI\View\Helper\FormHelper::ERROR_STYLE_TOOLTIP,
+    'feedbackStyle' => \BootstrapUI\View\Helper\FormHelper::FEEDBACK_STYLE_TOOLTIP,
     'formGroupPosition' => \BootstrapUI\View\Helper\FormHelper::POSITION_ABSOLUTE,
 ]);
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -15,25 +15,18 @@ class FormHelper extends Helper
     use OptionsAwareTrait;
 
     /**
-     * The default error style.
+     * The default feedback style.
      *
      * @var string
      */
-    public const ERROR_STYLE_DEFAULT = 'default';
+    public const FEEDBACK_STYLE_DEFAULT = 'default';
 
     /**
-     * The none error style.
+     * The tooltip feedback style.
      *
      * @var string
      */
-    public const ERROR_STYLE_NONE = 'none';
-
-    /**
-     * The tooltip error style.
-     *
-     * @var string
-     */
-    public const ERROR_STYLE_TOOLTIP = 'tooltip';
+    public const FEEDBACK_STYLE_TOOLTIP = 'tooltip';
 
     /**
      * Absolute positioning.
@@ -370,8 +363,8 @@ class FormHelper extends Helper
      * - `inline` - Boolean for generating inline checkbox/radio.
      * - `help` - Help text to include in the input container.
      * - `tooltip` - Tooltip text to include in the control's label.
-     * - `errorStyle` - The error style to use, `default`, or `tooltip` (will cause `formGroupPosition` to be set to
-     *  `relative` unless explicitly configured otherwise).
+     * - `feedbackStyle` - The feedback style to use, `default`, or `tooltip` (will cause `formGroupPosition` to be set
+     *   to `relative` unless explicitly configured otherwise).
      * - `formGroupPosition` - CSS positioning of form groups, `absolute`, `fixed`, `relative`, `static`, or `sticky`.
      *
      * @param string $fieldName This should be "Modelname.fieldname".
@@ -381,7 +374,7 @@ class FormHelper extends Helper
     public function control(string $fieldName, array $options = []): string
     {
         $options += [
-            'errorStyle' => null,
+            'feedbackStyle' => null,
             'formGroupPosition' => null,
             'custom' => false,
             'prepend' => null,
@@ -433,7 +426,7 @@ class FormHelper extends Helper
                 break;
         }
 
-        $options = $this->_errorStyleOptions($fieldName, $options);
+        $options = $this->_feedbackStyleOptions($fieldName, $options);
         $options = $this->_helpOptions($fieldName, $options);
         $options = $this->_tooltipOptions($fieldName, $options);
 
@@ -446,7 +439,7 @@ class FormHelper extends Helper
 
         unset(
             $options['formGroupPosition'],
-            $options['errorStyle'],
+            $options['feedbackStyle'],
             $options['inline'],
             $options['nestedInput']
         );
@@ -687,25 +680,25 @@ class FormHelper extends Helper
      * @param array $options Options. See `$options` argument of `control()` method.
      * @return array
      */
-    protected function _errorStyleOptions(string $fieldName, array $options): array
+    protected function _feedbackStyleOptions(string $fieldName, array $options): array
     {
         $formGroupPosition = $options['formGroupPosition'] ?: $this->getConfig('formGroupPosition');
-        $errorStyle = $options['errorStyle'] ?: $this->getConfig('errorStyle');
+        $feedbackStyle = $options['feedbackStyle'] ?: $this->getConfig('feedbackStyle');
 
         if (
             $this->_align === static::ALIGN_INLINE &&
-            $errorStyle === null
+            $feedbackStyle === null
         ) {
-            $errorStyle = static::ERROR_STYLE_TOOLTIP;
+            $feedbackStyle = static::FEEDBACK_STYLE_TOOLTIP;
         }
 
-        if ($errorStyle === static::ERROR_STYLE_TOOLTIP) {
+        if ($feedbackStyle === static::FEEDBACK_STYLE_TOOLTIP) {
             $options['templates']['error'] = $this->templater()->get('errorTooltip');
         }
 
         if (
             $formGroupPosition === null &&
-            $errorStyle === static::ERROR_STYLE_TOOLTIP
+            $feedbackStyle === static::FEEDBACK_STYLE_TOOLTIP
         ) {
             $formGroupPosition = static::POSITION_RELATIVE;
         }

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -1738,14 +1738,14 @@ class FormHelperTest extends TestCase
         $this->Form->create($this->article, ['align' => 'foo']);
     }
 
-    public function testErrorStyleFromHelperConfig()
+    public function testFeedbackStyleFromHelperConfig()
     {
         $this->article['errors'] = [
             'title' => ['error message'],
         ];
         $this->article['required']['title'] = false;
 
-        $this->Form->setConfig('errorStyle', FormHelper::ERROR_STYLE_TOOLTIP);
+        $this->Form->setConfig('feedbackStyle', FormHelper::FEEDBACK_STYLE_TOOLTIP);
         $this->Form->create($this->article);
 
         $result = $this->Form->control('title');
@@ -1769,18 +1769,18 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
     }
 
-    public function testOverrideErrorStyleFromHelperConfigViaControlConfig()
+    public function testOverrideFeedbackStyleFromHelperConfigViaControlConfig()
     {
         $this->article['errors'] = [
             'title' => ['error message'],
         ];
         $this->article['required']['title'] = false;
 
-        $this->Form->setConfig('errorStyle', FormHelper::ERROR_STYLE_TOOLTIP);
+        $this->Form->setConfig('feedbackStyle', FormHelper::FEEDBACK_STYLE_TOOLTIP);
         $this->Form->create($this->article);
 
         $result = $this->Form->control('title', [
-            'errorStyle' => FormHelper::ERROR_STYLE_DEFAULT,
+            'feedbackStyle' => FormHelper::FEEDBACK_STYLE_DEFAULT,
         ]);
 
         $expected = [
@@ -1810,7 +1810,7 @@ class FormHelperTest extends TestCase
         $this->article['required']['title'] = false;
 
         $this->Form->setConfig([
-            'errorStyle' => FormHelper::ERROR_STYLE_TOOLTIP,
+            'feedbackStyle' => FormHelper::FEEDBACK_STYLE_TOOLTIP,
             'formGroupPosition' => FormHelper::POSITION_ABSOLUTE,
         ]);
         $this->Form->create($this->article);
@@ -1844,7 +1844,7 @@ class FormHelperTest extends TestCase
         $this->article['required']['title'] = false;
 
         $this->Form->setConfig([
-            'errorStyle' => FormHelper::ERROR_STYLE_TOOLTIP,
+            'feedbackStyle' => FormHelper::FEEDBACK_STYLE_TOOLTIP,
             'formGroupPosition' => FormHelper::POSITION_ABSOLUTE,
         ]);
         $this->Form->create($this->article);
@@ -1872,7 +1872,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
     }
 
-    public function testDefaultAlignControlWithTooltipErrorStyle()
+    public function testDefaultAlignControlWithTooltipFeedbackStyle()
     {
         $this->article['errors'] = [
             'title' => ['error message'],
@@ -1882,7 +1882,7 @@ class FormHelperTest extends TestCase
         $this->Form->create($this->article);
 
         $result = $this->Form->control('title', [
-            'errorStyle' => FormHelper::ERROR_STYLE_TOOLTIP,
+            'feedbackStyle' => FormHelper::FEEDBACK_STYLE_TOOLTIP,
         ]);
 
         $expected = [
@@ -1904,7 +1904,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
     }
 
-    public function testInlineAlignControlWithDefaultErrorStyle()
+    public function testInlineAlignControlWithDefaultFeedbackStyle()
     {
         $this->article['errors'] = [
             'title' => ['error message'],
@@ -1916,7 +1916,7 @@ class FormHelperTest extends TestCase
         ]);
 
         $result = $this->Form->control('title', [
-            'errorStyle' => FormHelper::ERROR_STYLE_DEFAULT,
+            'feedbackStyle' => FormHelper::FEEDBACK_STYLE_DEFAULT,
         ]);
 
         $expected = [
@@ -1938,7 +1938,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
     }
 
-    public function testHorizontalAlignControlWithTooltipErrorStyle()
+    public function testHorizontalAlignControlWithTooltipFeedbackStyle()
     {
         $this->article['errors'] = [
             'title' => ['error message'],
@@ -1955,7 +1955,7 @@ class FormHelperTest extends TestCase
         ]);
 
         $result = $this->Form->control('title', [
-            'errorStyle' => FormHelper::ERROR_STYLE_TOOLTIP,
+            'feedbackStyle' => FormHelper::FEEDBACK_STYLE_TOOLTIP,
         ]);
 
         $expected = [


### PR DESCRIPTION
While the helper currently only supports error state feedback, ie valid state feedback isn't yet supported (https://github.com/FriendsOfCake/bootstrap-ui/issues/223#issuecomment-654885462), switching to a more generic terminology now will probably make things easier further down the road.