### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ When no layout for the view is defined, the `BootstrapUI\View\UIViewTrait` will 
 You can override this behavior in two ways.
 
 - Assign a layout to the template with `$this->setLayout('layout')`.
-- Disable auto loading of the layout in `BootstrapUI\View\UIViewTrait` with `$this->initializeUI(['layout' => false]);`.
+- Disable auto loading of the layout in `BootstrapUI\View\UIViewTrait` by adding `$this->initializeUI(['layout' => false]);` to your `AppView`'s `initialize()` function.
 
 #### Using the example layouts
 


### PR DESCRIPTION
I updated the README's how-to section on disabling the default layout by specifying that `$this->initializeUI(['layout' => 'default']);` needs to be added to the `AppView`'s `initialize()` function, as I had to try a bit to figure out where to add it myself.

## Description
Update a section of the README's how-to section by specifing where to disable the default layout.

## Summarize
- Changed the README

## Benefits
More clear instructions in the how-to section of the README.