### PR TITLE
Fix Breadcrumbs Item Class not added

### DIFF
--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -49,6 +49,21 @@ class BreadcrumbsHelper extends CoreBreadcrumbsHelper
      */
     public function add($title, $url = null, array $options = [])
     {
+        if (is_array($title)) {
+            $crumbs = [];
+            foreach ($title as $crumb) {
+                $options = [];
+                if (isset($crumb['options'])) {
+                    $options = $crumb['options'];
+                }
+
+                $crumb['options'] = $this->injectClasses($this->_defaultAttributes['class']['item'], $options);
+                $crumbs[] = $crumb + ['title' => '', 'url' => null, 'options' => []];
+            }
+
+            return parent::add($crumbs);
+        }
+
         $options = $this->injectClasses($this->_defaultAttributes['class']['item'], $options);
 
         return parent::add($title, $url, $options);

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -87,6 +87,39 @@ class BreadcrumbsHelperTest extends TestCase
         $this->assertHtml($expected, $result);
     }
 
+    public function testCrumbListAddMultiple()
+    {
+        $result = $this->Breadcrumbs->add([
+            ['title' => 'Home', 'url' => '/', 'options' => ['class' => 'xyz']],
+            ['title' => 'page'],
+            ['title' => 'subpage', 'url' => null],
+        ])->render();
+
+        $expected = [
+            'nav' => ['aria-label' => 'breadcrumb'],
+                'ol' => ['class' => 'breadcrumb'],
+                    ['li' => ['class' => 'xyz breadcrumb-item']],
+                        ['a' => ['href' => '/']],
+                        'Home',
+                        '/a',
+                    '/li',
+                    ['li' => ['class' => 'breadcrumb-item']],
+                        ['span' => true],
+                        'page',
+                        '/span',
+                    '/li',
+                    ['li' => ['class' => 'breadcrumb-item active', 'aria-current' => 'page']],
+                        ['span' => true],
+                        'subpage',
+                        '/span',
+                    '/li',
+                '/ol',
+            '/nav',
+        ];
+
+        $this->assertHtml($expected, $result);
+    }
+
     public function testAttributes()
     {
         $attributes = [


### PR DESCRIPTION
(cherry picked from commit b11514e16d41c351bde03e0a216465280f45e682)

## Description
Fix for issue #299 in 2.x branch, for the people still on Cake 3.x
