### PR TITLE
Fix alert positioned wrongly in signin view.

### DIFF
--- a/webroot/css/signin.css
+++ b/webroot/css/signin.css
@@ -7,6 +7,9 @@ body {
     display: -ms-flexbox;
     display: -webkit-box;
     display: flex;
+    -ms-flex-direction: column;
+    -webit-flex-direction: column;
+    flex-direction: column;
     -ms-flex-align: center;
     -ms-flex-pack: center;
     -webkit-box-align: center;


### PR DESCRIPTION
Flexbox is by default using row direction, causing the alert and the
form to be aligned horizontally.

The view would look like this now:

![image](https://user-images.githubusercontent.com/5031606/106466179-4b3e1380-649b-11eb-9b98-13be9aaab1e9.png)

fixes #342 
