### PR TITLE
Fix label `class` option not working for various controls.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -123,7 +123,7 @@ class FormHelper extends Helper
             '<div{{containerAttrs}} ' .
                 'class="{{containerClass}}form-group {{formGroupPosition}}{{type}}{{required}} is-invalid" ' .
                     'role="group" aria-labelledby="{{groupId}}">{{content}}{{error}}{{help}}</div>',
-        'datetimeLabel' => '<label id="{{groupId}}">{{text}}{{tooltip}}</label>',
+        'datetimeLabel' => '<label{{attrs}}>{{text}}{{tooltip}}</label>',
         'inputContainer' =>
             '<div{{containerAttrs}} ' .
                 'class="{{containerClass}}form-group {{type}}{{required}}">{{content}}{{help}}</div>',
@@ -173,7 +173,7 @@ class FormHelper extends Helper
             '<div{{containerAttrs}} ' .
                 'class="{{containerClass}}form-group {{formGroupPosition}}{{type}}{{required}} is-invalid" ' .
                     'role="group" aria-labelledby="{{groupId}}">{{content}}{{error}}{{help}}</div>',
-        'radioLabel' => '<label id="{{groupId}}" class="d-block">{{text}}{{tooltip}}</label>',
+        'radioLabel' => '<label{{attrs}}>{{text}}{{tooltip}}</label>',
         'radioWrapper' => '<div class="form-check">{{hidden}}{{label}}</div>',
         'radioInlineWrapper' => '<div class="form-check form-check-inline">{{label}}</div>',
         'customRadioWrapper' => '<div class="custom-control custom-radio">{{hidden}}{{label}}</div>',
@@ -190,10 +190,10 @@ class FormHelper extends Helper
             '<div{{containerAttrs}} ' .
                 'class="{{containerClass}}form-group {{formGroupPosition}}{{type}}{{required}} is-invalid" ' .
                     'role="group" aria-labelledby="{{groupId}}">{{content}}{{error}}{{help}}</div>',
-        'multicheckboxLabel' => '<label id="{{groupId}}" class="d-block">{{text}}{{tooltip}}</label>',
+        'multicheckboxLabel' => '<label{{attrs}}>{{text}}{{tooltip}}</label>',
         'multicheckboxWrapper' => '<fieldset class="form-group">{{content}}</fieldset>',
         'multicheckboxTitle' => '<legend class="col-form-label pt-0">{{text}}</legend>',
-        'customFileLabel' => '<label class="custom-file-label"{{attrs}}>{{text}}{{tooltip}}</label>',
+        'customFileLabel' => '<label{{attrs}}>{{text}}{{tooltip}}</label>',
         'customFileFormGroup' => '<div class="custom-file {{invalid}}">{{input}}{{label}}</div>',
         'customFileInputGroupFormGroup' => '{{input}}',
         'customFileInputGroupContainer' =>
@@ -212,7 +212,6 @@ class FormHelper extends Helper
         'default' => [
         ],
         'inline' => [
-            'label' => '<label class="sr-only"{{attrs}}>{{text}}{{tooltip}}</label>',
             'help' => '<small{{attrs}} class="sr-only form-text text-muted">{{content}}</small>',
             'checkboxInlineContainer' =>
                 '<div{{containerAttrs}} class="{{containerClass}}form-check form-check-inline {{type}}{{required}}">' .
@@ -238,7 +237,7 @@ class FormHelper extends Helper
                 '<div{{containerAttrs}} ' .
                     'class="{{containerClass}}form-group {{formGroupPosition}}{{type}}{{required}} is-invalid" ' .
                         'role="group" aria-labelledby="{{groupId}}">{{content}}{{error}}{{help}}</div>',
-            'datetimeLabel' => '<span id="{{groupId}}" class="sr-only">{{text}}{{tooltip}}</span>',
+            'datetimeLabel' => '<span{{attrs}}>{{text}}{{tooltip}}</span>',
             'radioContainer' =>
                 '<div{{containerAttrs}} ' .
                     'class="{{containerClass}}form-group {{formGroupPosition}}{{type}}{{required}}" role="group" ' .
@@ -247,7 +246,7 @@ class FormHelper extends Helper
                 '<div{{containerAttrs}} ' .
                     'class="{{containerClass}}form-group {{formGroupPosition}}{{type}}{{required}} is-invalid" ' .
                         'role="group" aria-labelledby="{{groupId}}">{{content}}{{error}}{{help}}</div>',
-            'radioLabel' => '<span id="{{groupId}}" class="sr-only">{{text}}{{tooltip}}</span>',
+            'radioLabel' => '<span{{attrs}}>{{text}}{{tooltip}}</span>',
             'multicheckboxContainer' =>
                 '<div{{containerAttrs}} ' .
                     'class="{{containerClass}}form-group {{formGroupPosition}}{{type}}{{required}}" role="group" ' .
@@ -256,11 +255,11 @@ class FormHelper extends Helper
                 '<div{{containerAttrs}} ' .
                     'class="{{containerClass}}form-group {{formGroupPosition}}{{type}}{{required}} is-invalid" ' .
                         'role="group" aria-labelledby="{{groupId}}">{{content}}{{error}}{{help}}</div>',
-            'multicheckboxLabel' => '<span id="{{groupId}}" class="sr-only">{{text}}{{tooltip}}</span>',
+            'multicheckboxLabel' => '<span{{attrs}}>{{text}}{{tooltip}}</span>',
         ],
         'horizontal' => [
-            'label' => '<label class="col-form-label %s"{{attrs}}>{{text}}{{tooltip}}</label>',
-            'fileLabel' => '<label class="col-form-label pt-1 %s"{{attrs}}>{{text}}{{tooltip}}</label>',
+            'label' => '<label{{attrs}}>{{text}}{{tooltip}}</label>',
+            'fileLabel' => '<label{{attrs}}>{{text}}{{tooltip}}</label>',
             'formGroup' => '{{label}}<div class="%s">{{input}}{{error}}{{help}}</div>',
             'customFileFormGroup' =>
                 '<div class="%s"><div class="custom-file {{invalid}}">{{input}}{{label}}</div>{{error}}{{help}}</div>',
@@ -276,7 +275,7 @@ class FormHelper extends Helper
                 '<div{{containerAttrs}} ' .
                     'class="{{containerClass}}form-group row {{formGroupPosition}}{{type}}{{required}} is-invalid" ' .
                         'role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
-            'datetimeLabel' => '<label id="{{groupId}}" class="col-form-label %s">{{text}}{{tooltip}}</label>',
+            'datetimeLabel' => '<label{{attrs}}>{{text}}{{tooltip}}</label>',
             'checkboxInlineFormGroup' => '<div class="%s"><div class="form-check form-check-inline">' .
                     '{{input}}{{label}}</div></div>',
             'submitContainer' =>
@@ -304,7 +303,7 @@ class FormHelper extends Helper
                     'class="{{containerClass}}form-group row {{formGroupPosition}}{{type}}{{required}} is-invalid" ' .
                         'role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
             'radioLabel' =>
-                '<label id="{{groupId}}" class="col-form-label d-block pt-0 %s">{{text}}{{tooltip}}</label>',
+                '<label{{attrs}}>{{text}}{{tooltip}}</label>',
             'multicheckboxContainer' =>
                 '<div{{containerAttrs}} class="{{containerClass}}form-group row {{type}}{{required}}" role="group" ' .
                     'aria-labelledby="{{groupId}}">{{content}}</div>',
@@ -313,7 +312,7 @@ class FormHelper extends Helper
                     'class="{{containerClass}}form-group row {{formGroupPosition}}{{type}}{{required}} is-invalid" ' .
                         'role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
             'multicheckboxLabel' =>
-                '<label id="{{groupId}}" class="col-form-label d-block pt-0 %s">{{text}}{{tooltip}}</label>',
+                '<label{{attrs}}>{{text}}{{tooltip}}</label>',
         ],
     ];
 
@@ -471,15 +470,13 @@ class FormHelper extends Helper
             case 'radio':
             case 'select':
             case 'file':
+            case 'range':
                 $function = '_' . $options['type'] . 'Options';
                 $options = $this->{$function}($fieldName, $options);
                 break;
 
-            case 'range':
-                if ($options['custom']) {
-                    $options['injectFormControl'] = false;
-                    $options = $this->injectClasses('custom-range', $options);
-                }
+            default:
+                $options = $this->_labelOptions($fieldName, $options);
                 break;
         }
 
@@ -551,12 +548,15 @@ class FormHelper extends Helper
      */
     protected function _dateTimeOptions(string $fieldName, array $options): array
     {
+        $options = $this->_labelOptions($fieldName, $options);
+
         $groupId =
         $options['templateVars']['groupId'] =
             $this->_domId($fieldName . '-group-label');
 
         if ($options['label'] !== false) {
             $options['label']['templateVars']['groupId'] = $groupId;
+            $options['label']['id'] = $groupId;
         }
 
         $options['templates']['label'] = $this->templater()->get('datetimeLabel');
@@ -642,6 +642,27 @@ class FormHelper extends Helper
 
         if ($options['label'] !== false) {
             $options['label']['templateVars']['groupId'] = $groupId;
+            $options['label']['id'] = $groupId;
+        }
+
+        if ($options['label'] !== false) {
+            $labelClasses = [];
+            if ($this->_align === static::ALIGN_HORIZONTAL) {
+                $labelClasses[] = 'col-form-label';
+            }
+            if ($this->_align !== static::ALIGN_INLINE) {
+                $labelClasses[] = 'd-block';
+            }
+            if ($this->_align === static::ALIGN_HORIZONTAL) {
+                $size = $this->_gridClass('left');
+                $labelClasses[] = "pt-0 $size";
+            }
+            if ($this->_align === static::ALIGN_INLINE) {
+                $labelClasses[] = 'sr-only';
+            }
+            if ($labelClasses) {
+                $options['label'] = $this->injectClasses($labelClasses, (array)$options['label']);
+            }
         }
 
         $options['templates']['label'] = $this->templater()->get('radioLabel');
@@ -673,6 +694,8 @@ class FormHelper extends Helper
      */
     protected function _selectOptions(string $fieldName, array $options): array
     {
+        $labelClasses = [];
+
         if (isset($options['multiple']) && $options['multiple'] === 'checkbox') {
             $options['type'] = 'multicheckbox';
 
@@ -682,6 +705,20 @@ class FormHelper extends Helper
 
             if ($options['label'] !== false) {
                 $options['label']['templateVars']['groupId'] = $groupId;
+                $options['label']['id'] = $groupId;
+            }
+
+            if ($options['label'] !== false) {
+                if ($this->_align === static::ALIGN_HORIZONTAL) {
+                    $labelClasses[] = 'col-form-label';
+                }
+                if ($this->_align !== static::ALIGN_INLINE) {
+                    $labelClasses[] = 'd-block';
+                }
+                if ($this->_align === static::ALIGN_HORIZONTAL) {
+                    $size = $this->_gridClass('left');
+                    $labelClasses[] = "pt-0 $size";
+                }
             }
 
             $options['templates']['label'] = $this->templater()->get('multicheckboxLabel');
@@ -707,6 +744,25 @@ class FormHelper extends Helper
             if ($options['nestedInput']) {
                 $options['templates']['nestingLabel'] = $this->templater()->get('nestingLabelNestedInput');
             }
+        } else {
+            if (
+                $this->_align === static::ALIGN_HORIZONTAL &&
+                $options['label'] !== false
+            ) {
+                $size = $this->_gridClass('left');
+                $labelClasses[] = "col-form-label $size";
+            }
+        }
+
+        if (
+            $this->_align === static::ALIGN_INLINE &&
+            $options['label'] !== false
+        ) {
+            $labelClasses[] = 'sr-only';
+        }
+
+        if ($labelClasses) {
+            $options['label'] = $this->injectClasses($labelClasses, (array)$options['label']);
         }
 
         if (
@@ -730,6 +786,20 @@ class FormHelper extends Helper
     protected function _fileOptions(string $fieldName, array $options): array
     {
         if (!$options['custom']) {
+            if ($options['label'] !== false) {
+                $labelClasses = [];
+                if ($this->_align === static::ALIGN_HORIZONTAL) {
+                    $size = $this->_gridClass('left');
+                    $labelClasses[] = "col-form-label pt-1 $size";
+                }
+                if ($this->_align === static::ALIGN_INLINE) {
+                    $labelClasses[] = 'sr-only';
+                }
+                if ($labelClasses) {
+                    $options['label'] = $this->injectClasses($labelClasses, (array)$options['label']);
+                }
+            }
+
             if ($this->_align === static::ALIGN_HORIZONTAL) {
                 $options['templates']['label'] = $this->templater()->get('fileLabel');
             }
@@ -742,6 +812,10 @@ class FormHelper extends Helper
 
             if ($this->_getContext()->hasError($fieldName)) {
                 $options['templateVars']['invalid'] = $this->_config['errorClass'];
+            }
+
+            if ($options['label'] !== false) {
+                $options['label'] = $this->injectClasses('custom-file-label', (array)$options['label']);
             }
 
             if (
@@ -768,6 +842,51 @@ class FormHelper extends Helper
                 $options['templates']['formGroup'] = $this->templater()->get('customFileInputGroupFormGroup');
                 $container = $this->templater()->get('customFileInputGroupContainer');
                 $options['templates']['inputGroupContainer'] = $container;
+            }
+        }
+
+        return $options;
+    }
+
+    /**
+     * Modify options for range controls.
+     *
+     * @param string $fieldName Field name.
+     * @param array $options Options. See `$options` argument of `control()` method.
+     * @return array
+     */
+    protected function _rangeOptions(string $fieldName, array $options): array
+    {
+        $options = $this->_labelOptions($fieldName, $options);
+
+        if ($options['custom']) {
+            $options['injectFormControl'] = false;
+            $options = $this->injectClasses('custom-range', $options);
+        }
+
+        return $options;
+    }
+
+    /**
+     * Modify the options for labels.
+     *
+     * @param string|null $fieldName Field name.
+     * @param array $options Options. See `$options` argument of `control()` method.
+     * @return array
+     */
+    protected function _labelOptions(?string $fieldName, array $options): array
+    {
+        if ($options['label'] !== false) {
+            $labelClasses = [];
+            if ($this->_align === static::ALIGN_HORIZONTAL) {
+                $size = $this->_gridClass('left');
+                $labelClasses[] = "col-form-label $size";
+            }
+            if ($this->_align === static::ALIGN_INLINE) {
+                $labelClasses[] = 'sr-only';
+            }
+            if ($labelClasses) {
+                $options['label'] = $this->injectClasses($labelClasses, (array)$options['label']);
             }
         }
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -117,12 +117,12 @@ class FormHelper extends Helper
         'help' => '<small{{attrs}} class="form-text text-muted">{{content}}</small>',
         'tooltip' => '<span data-toggle="tooltip" title="{{content}}" class="fas fa-info-circle"></span>',
         'datetimeContainer' =>
-            '<div{{containerAttrs}} class="{{containerClass}}form-group {{type}}{{required}}" role="group" ' .
-                'aria-labelledby="{{groupId}}">{{content}}{{help}}</div>',
+            '<div{{containerAttrs}} ' .
+                'class="{{containerClass}}form-group {{type}}{{required}}">{{content}}{{help}}</div>',
         'datetimeContainerError' =>
             '<div{{containerAttrs}} ' .
-                'class="{{containerClass}}form-group {{formGroupPosition}}{{type}}{{required}} is-invalid" ' .
-                    'role="group" aria-labelledby="{{groupId}}">{{content}}{{error}}{{help}}</div>',
+                'class="{{containerClass}}form-group {{formGroupPosition}}{{type}}{{required}} is-invalid">' .
+                    '{{content}}{{error}}{{help}}</div>',
         'datetimeLabel' => '<label{{attrs}}>{{text}}{{tooltip}}</label>',
         'inputContainer' =>
             '<div{{containerAttrs}} ' .
@@ -231,13 +231,13 @@ class FormHelper extends Helper
                         '{{formGroupPosition}}{{type}}{{required}} is-invalid">{{content}}{{error}}{{help}}</div>',
             'datetimeContainer' =>
                 '<div{{containerAttrs}} ' .
-                    'class="{{containerClass}}form-group {{formGroupPosition}}{{type}}{{required}}" ' .
-                        'role="group" aria-labelledby="{{groupId}}">{{content}}{{help}}</div>',
+                    'class="{{containerClass}}form-group {{formGroupPosition}}{{type}}{{required}}">' .
+                        '{{content}}{{help}}</div>',
             'datetimeContainerError' =>
                 '<div{{containerAttrs}} ' .
-                    'class="{{containerClass}}form-group {{formGroupPosition}}{{type}}{{required}} is-invalid" ' .
-                        'role="group" aria-labelledby="{{groupId}}">{{content}}{{error}}{{help}}</div>',
-            'datetimeLabel' => '<span{{attrs}}>{{text}}{{tooltip}}</span>',
+                    'class="{{containerClass}}form-group {{formGroupPosition}}{{type}}{{required}} is-invalid">' .
+                        '{{content}}{{error}}{{help}}</div>',
+            'datetimeLabel' => '<label{{attrs}}>{{text}}{{tooltip}}</label>',
             'radioContainer' =>
                 '<div{{containerAttrs}} ' .
                     'class="{{containerClass}}form-group {{formGroupPosition}}{{type}}{{required}}" role="group" ' .
@@ -269,12 +269,12 @@ class FormHelper extends Helper
             'customCheckboxFormGroup' => '<div class="%s"><div class="custom-control custom-checkbox">' .
                     '{{input}}{{label}}{{error}}{{help}}</div></div>',
             'datetimeContainer' =>
-                '<div{{containerAttrs}} class="{{containerClass}}form-group row {{type}}{{required}}" role="group" ' .
-                    'aria-labelledby="{{groupId}}">{{content}}</div>',
+                '<div{{containerAttrs}} ' .
+                    'class="{{containerClass}}form-group row {{type}}{{required}}">{{content}}</div>',
             'datetimeContainerError' =>
                 '<div{{containerAttrs}} ' .
-                    'class="{{containerClass}}form-group row {{formGroupPosition}}{{type}}{{required}} is-invalid" ' .
-                        'role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
+                    'class="{{containerClass}}form-group row {{formGroupPosition}}{{type}}{{required}} is-invalid">' .
+                        '{{content}}</div>',
             'datetimeLabel' => '<label{{attrs}}>{{text}}{{tooltip}}</label>',
             'checkboxInlineFormGroup' => '<div class="%s"><div class="form-check form-check-inline">' .
                     '{{input}}{{label}}</div></div>',
@@ -550,13 +550,15 @@ class FormHelper extends Helper
     {
         $options = $this->_labelOptions($fieldName, $options);
 
+        // group IDs are no longer required for date/time controls,
+        // this is just kept for backwards compatibility
+
         $groupId =
         $options['templateVars']['groupId'] =
             $this->_domId($fieldName . '-group-label');
 
         if ($options['label'] !== false) {
             $options['label']['templateVars']['groupId'] = $groupId;
-            $options['label']['id'] = $groupId;
         }
 
         $options['templates']['label'] = $this->templater()->get('datetimeLabel');

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -824,9 +824,6 @@ class FormHelper extends Helper
                 $options['prepend'] ||
                 $options['append']
             ) {
-                if ($options['label'] === null) {
-                    $options['label'] = [];
-                }
                 if (
                     $options['label'] !== false &&
                     !isset($options['label']['text'])

--- a/tests/TestCase/View/Helper/FormHelper/DefaultAlign/CheckboxControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/DefaultAlign/CheckboxControlTest.php
@@ -93,6 +93,44 @@ class CheckboxControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testDefaultAlignCheckboxControlWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'type' => 'checkbox',
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group form-check checkbox']],
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => 0,
+                ]],
+                ['input' => [
+                    'class' => 'form-check-input',
+                    'type' => 'checkbox',
+                    'name' => 'users',
+                    'id' => 'users',
+                    'value' => 1,
+                ]],
+                ['label' => [
+                    'class' => 'custom-label-class form-check-label',
+                    'foo' => 'bar',
+                    'for' => 'users',
+                ]],
+                    'Custom Label',
+                '/label',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testDefaultAlignCheckboxControlWithHelp()
     {
         $this->Form->create($this->article);
@@ -499,6 +537,45 @@ class CheckboxControlTest extends AbstractFormHelperTest
                     'value' => 1,
                 ]],
                 ['label' => ['class' => 'form-check-label', 'for' => 'users']],
+                    'Custom Label',
+                '/label',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignCheckboxControlInlineWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'type' => 'checkbox',
+            'inline' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-check form-check-inline checkbox']],
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => 0,
+                ]],
+                ['input' => [
+                    'class' => 'form-check-input',
+                    'type' => 'checkbox',
+                    'name' => 'users',
+                    'id' => 'users',
+                    'value' => 1,
+                ]],
+                ['label' => [
+                    'class' => 'custom-label-class form-check-label',
+                    'foo' => 'bar',
+                    'for' => 'users',
+                ]],
                     'Custom Label',
                 '/label',
             '/div',

--- a/tests/TestCase/View/Helper/FormHelper/DefaultAlign/CheckboxCustomControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/DefaultAlign/CheckboxCustomControlTest.php
@@ -96,6 +96,45 @@ class CheckboxCustomControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testDefaultAlignCustomCheckboxControlWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'type' => 'checkbox',
+            'custom' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group custom-control custom-checkbox checkbox']],
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => 0,
+                ]],
+                ['input' => [
+                    'type' => 'checkbox',
+                    'name' => 'users',
+                    'value' => '1',
+                    'id' => 'users',
+                    'class' => 'custom-control-input',
+                ]],
+                ['label' => [
+                    'class' => 'custom-label-class custom-control-label',
+                    'foo' => 'bar',
+                    'for' => 'users',
+                ]],
+                    'Custom Label',
+                '/label',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testDefaultAlignCustomCheckboxControlWithHelp()
     {
         $this->Form->create($this->article);
@@ -407,6 +446,46 @@ class CheckboxCustomControlTest extends AbstractFormHelperTest
                     'class' => 'custom-control-input',
                 ]],
                 ['label' => ['class' => 'custom-control-label', 'for' => 'users']],
+                    'Custom Label',
+                '/label',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignCustomCheckboxControlInlineWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'type' => 'checkbox',
+            'custom' => true,
+            'inline' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group custom-control custom-checkbox custom-control-inline checkbox']],
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => 0,
+                ]],
+                ['input' => [
+                    'type' => 'checkbox',
+                    'name' => 'users',
+                    'value' => '1',
+                    'id' => 'users',
+                    'class' => 'custom-control-input',
+                ]],
+                ['label' => [
+                    'class' => 'custom-label-class custom-control-label',
+                    'foo' => 'bar',
+                    'for' => 'users',
+                ]],
                     'Custom Label',
                 '/label',
             '/div',

--- a/tests/TestCase/View/Helper/FormHelper/DefaultAlign/DateTimeControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/DefaultAlign/DateTimeControlTest.php
@@ -20,7 +20,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
 
         $expected = [
             ['div' => ['class' => 'form-group datetime-local', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['label' => ['id' => 'created-group-label']],
+                ['label' => ['id' => 'created-group-label', 'for' => 'created']],
                     'Created',
                 '/label',
                 'input' => [
@@ -83,7 +83,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
                 'role' => 'group',
                 'aria-labelledby' => 'created-group-label',
             ]],
-                ['label' => ['id' => 'created-group-label']],
+                ['label' => ['id' => 'created-group-label', 'for' => 'created']],
                     'Custom Label',
                 '/label',
                 'input' => [
@@ -96,6 +96,86 @@ class DateTimeControlTest extends AbstractFormHelperTest
             '/div',
         ];
         $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignDateTimeControlWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article);
+
+        $now = new \DateTime('now');
+
+        $result = $this->Form->control('created', [
+            'type' => 'datetime-local',
+            'value' => $now->format('Y-m-d H:i:s'),
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+
+        $expected = [
+            ['div' => [
+                'class' => 'form-group datetime-local',
+                'role' => 'group',
+                'aria-labelledby' => 'created-group-label',
+            ]],
+                ['label' => [
+                    'id' => 'created-group-label',
+                    'class' => 'custom-label-class',
+                    'foo' => 'bar',
+                    'for' => 'created',
+                ]],
+                    'Custom Label',
+                '/label',
+                'input' => [
+                    'type' => 'datetime-local',
+                    'name' => 'created',
+                    'id' => 'created',
+                    'class' => 'form-control',
+                    'value' => $now->format('Y-m-d H:i:s'),
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignDateTimeControlWithCustomLabelTemplateIsBackwardsCompatible()
+    {
+        $this->Form->create($this->article);
+
+        $now = new \DateTime('now');
+
+        $result = $this->Form->control('created', [
+            'type' => 'datetime-local',
+            'value' => $now->format('Y-m-d H:i:s'),
+            'templates' => [
+                'datetimeLabel' => '<label id="{{groupId}}" back="compat">{{text}}{{tooltip}}</label>',
+            ],
+        ]);
+
+        $expected = [
+            ['div' => [
+                'class' => 'form-group datetime-local',
+                'role' => 'group',
+                'aria-labelledby' => 'created-group-label',
+            ]],
+                ['label' => [
+                    'id' => 'created-group-label',
+                    'back' => 'compat',
+                ]],
+                    'Created',
+                '/label',
+                'input' => [
+                    'type' => 'datetime-local',
+                    'name' => 'created',
+                    'id' => 'created',
+                    'class' => 'form-control',
+                    'value' => $now->format('Y-m-d H:i:s'),
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result, true);
     }
 
     public function testDefaultAlignDateTimeControlWithHelp()
@@ -111,7 +191,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
         ]);
         $expected = [
             ['div' => ['class' => 'form-group time', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['label' => ['id' => 'created-group-label']],
+                ['label' => ['id' => 'created-group-label', 'for' => 'created']],
                     'Created',
                 '/label',
                 'input' => [
@@ -146,7 +226,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
         ]);
         $expected = [
             ['div' => ['class' => 'form-group time', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['label' => ['id' => 'created-group-label']],
+                ['label' => ['id' => 'created-group-label', 'for' => 'created']],
                     'Created',
                 '/label',
                 'input' => [
@@ -178,7 +258,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
         ]);
         $expected = [
             ['div' => ['class' => 'form-group time', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['label' => ['id' => 'created-group-label']],
+                ['label' => ['id' => 'created-group-label', 'for' => 'created']],
                     'Created ',
                     'span' => [
                         'data-toggle' => 'tooltip',
@@ -220,7 +300,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
                 'role' => 'group',
                 'aria-labelledby' => 'created-group-label',
             ]],
-                ['label' => ['id' => 'created-group-label']],
+                ['label' => ['id' => 'created-group-label', 'for' => 'created']],
                     'Created',
                 '/label',
                 'input' => [
@@ -260,7 +340,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
                 'role' => 'group',
                 'aria-labelledby' => 'created-group-label',
             ]],
-                ['label' => ['id' => 'created-group-label']],
+                ['label' => ['id' => 'created-group-label', 'for' => 'created']],
                     'Created',
                 '/label',
                 'input' => [
@@ -300,7 +380,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
                 'role' => 'group',
                 'aria-labelledby' => 'created-group-label',
             ]],
-                ['label' => ['id' => 'created-group-label']],
+                ['label' => ['id' => 'created-group-label', 'for' => 'created']],
                     'Created',
                 '/label',
                 'input' => [
@@ -330,7 +410,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
         ]);
         $expected = [
             ['div' => ['class' => 'form-group date', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['label' => ['id' => 'created-group-label']],
+                ['label' => ['id' => 'created-group-label', 'for' => 'created']],
                     'Created',
                 '/label',
                 'input' => [
@@ -357,7 +437,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
         ]);
         $expected = [
             ['div' => ['class' => 'form-group time', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['label' => ['id' => 'created-group-label']],
+                ['label' => ['id' => 'created-group-label', 'for' => 'created']],
                     'Created',
                 '/label',
                 'input' => [

--- a/tests/TestCase/View/Helper/FormHelper/DefaultAlign/DateTimeControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/DefaultAlign/DateTimeControlTest.php
@@ -19,8 +19,8 @@ class DateTimeControlTest extends AbstractFormHelperTest
         ]);
 
         $expected = [
-            ['div' => ['class' => 'form-group datetime-local', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['label' => ['id' => 'created-group-label', 'for' => 'created']],
+            ['div' => ['class' => 'form-group datetime-local']],
+                ['label' => ['for' => 'created']],
                     'Created',
                 '/label',
                 'input' => [
@@ -50,8 +50,6 @@ class DateTimeControlTest extends AbstractFormHelperTest
         $expected = [
             ['div' => [
                 'class' => 'form-group datetime-local',
-                'role' => 'group',
-                'aria-labelledby' => 'created-group-label',
             ]],
                 'input' => [
                     'type' => 'datetime-local',
@@ -80,10 +78,8 @@ class DateTimeControlTest extends AbstractFormHelperTest
         $expected = [
             ['div' => [
                 'class' => 'form-group datetime-local',
-                'role' => 'group',
-                'aria-labelledby' => 'created-group-label',
             ]],
-                ['label' => ['id' => 'created-group-label', 'for' => 'created']],
+                ['label' => ['for' => 'created']],
                     'Custom Label',
                 '/label',
                 'input' => [
@@ -117,11 +113,8 @@ class DateTimeControlTest extends AbstractFormHelperTest
         $expected = [
             ['div' => [
                 'class' => 'form-group datetime-local',
-                'role' => 'group',
-                'aria-labelledby' => 'created-group-label',
             ]],
                 ['label' => [
-                    'id' => 'created-group-label',
                     'class' => 'custom-label-class',
                     'foo' => 'bar',
                     'for' => 'created',
@@ -150,6 +143,9 @@ class DateTimeControlTest extends AbstractFormHelperTest
             'type' => 'datetime-local',
             'value' => $now->format('Y-m-d H:i:s'),
             'templates' => [
+                'datetimeContainer' =>
+                    '<div{{containerAttrs}} class="{{containerClass}}form-group {{type}}{{required}}" role="group" ' .
+                        'aria-labelledby="{{groupId}}">{{content}}{{help}}</div>',
                 'datetimeLabel' => '<label id="{{groupId}}" back="compat">{{text}}{{tooltip}}</label>',
             ],
         ]);
@@ -190,8 +186,8 @@ class DateTimeControlTest extends AbstractFormHelperTest
             'help' => 'Help text',
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group time', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['label' => ['id' => 'created-group-label', 'for' => 'created']],
+            ['div' => ['class' => 'form-group time']],
+                ['label' => ['for' => 'created']],
                     'Created',
                 '/label',
                 'input' => [
@@ -225,8 +221,8 @@ class DateTimeControlTest extends AbstractFormHelperTest
             ],
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group time', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['label' => ['id' => 'created-group-label', 'for' => 'created']],
+            ['div' => ['class' => 'form-group time']],
+                ['label' => ['for' => 'created']],
                     'Created',
                 '/label',
                 'input' => [
@@ -257,8 +253,8 @@ class DateTimeControlTest extends AbstractFormHelperTest
             'tooltip' => 'Tooltip text',
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group time', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['label' => ['id' => 'created-group-label', 'for' => 'created']],
+            ['div' => ['class' => 'form-group time']],
+                ['label' => ['for' => 'created']],
                     'Created ',
                     'span' => [
                         'data-toggle' => 'tooltip',
@@ -297,10 +293,8 @@ class DateTimeControlTest extends AbstractFormHelperTest
         $expected = [
             ['div' => [
                 'class' => 'form-group datetime-local is-invalid',
-                'role' => 'group',
-                'aria-labelledby' => 'created-group-label',
             ]],
-                ['label' => ['id' => 'created-group-label', 'for' => 'created']],
+                ['label' => ['for' => 'created']],
                     'Created',
                 '/label',
                 'input' => [
@@ -337,10 +331,8 @@ class DateTimeControlTest extends AbstractFormHelperTest
             ['div' => [
                 'attribute' => 'container-attribute',
                 'class' => 'container-class form-group datetime-local',
-                'role' => 'group',
-                'aria-labelledby' => 'created-group-label',
             ]],
-                ['label' => ['id' => 'created-group-label', 'for' => 'created']],
+                ['label' => ['for' => 'created']],
                     'Created',
                 '/label',
                 'input' => [
@@ -377,10 +369,8 @@ class DateTimeControlTest extends AbstractFormHelperTest
             ['div' => [
                 'attribute' => 'container-attribute',
                 'class' => 'container-class form-group datetime-local is-invalid',
-                'role' => 'group',
-                'aria-labelledby' => 'created-group-label',
             ]],
-                ['label' => ['id' => 'created-group-label', 'for' => 'created']],
+                ['label' => ['for' => 'created']],
                     'Created',
                 '/label',
                 'input' => [
@@ -409,8 +399,8 @@ class DateTimeControlTest extends AbstractFormHelperTest
             'value' => $now,
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group date', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['label' => ['id' => 'created-group-label', 'for' => 'created']],
+            ['div' => ['class' => 'form-group date']],
+                ['label' => ['for' => 'created']],
                     'Created',
                 '/label',
                 'input' => [
@@ -436,8 +426,8 @@ class DateTimeControlTest extends AbstractFormHelperTest
             'value' => $now,
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group time', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['label' => ['id' => 'created-group-label', 'for' => 'created']],
+            ['div' => ['class' => 'form-group time']],
+                ['label' => ['for' => 'created']],
                     'Created',
                 '/label',
                 'input' => [
@@ -460,17 +450,17 @@ class DateTimeControlTest extends AbstractFormHelperTest
         $result = $this->Form->control('created', [
             'type' => 'datetime',
         ]);
-        $this->assertStringContainsString('<div class="form-group datetime" role="group" aria-labelledby="created-group-label">', $result);
+        $this->assertStringContainsString('<div class="form-group datetime">', $result);
 
         $result = $this->Form->control('created', [
             'type' => 'date',
         ]);
-        $this->assertStringContainsString('<div class="form-group date" role="group" aria-labelledby="created-group-label">', $result);
+        $this->assertStringContainsString('<div class="form-group date">', $result);
 
         $result = $this->Form->control('created', [
             'type' => 'time',
         ]);
-        $this->assertStringContainsString('<div class="form-group time" role="group" aria-labelledby="created-group-label">', $result);
+        $this->assertStringContainsString('<div class="form-group time">', $result);
 
         $this->Form->setTemplates([
             'datetimeContainer' => '<div class="custom datetimeContainer {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
@@ -505,17 +495,17 @@ class DateTimeControlTest extends AbstractFormHelperTest
         $result = $this->Form->control('created', [
             'type' => 'datetime',
         ]);
-        $this->assertStringContainsString('<div class="form-group datetime is-invalid" role="group" aria-labelledby="created-group-label">', $result);
+        $this->assertStringContainsString('<div class="form-group datetime is-invalid">', $result);
 
         $result = $this->Form->control('created', [
             'type' => 'date',
         ]);
-        $this->assertStringContainsString('<div class="form-group date is-invalid" role="group" aria-labelledby="created-group-label">', $result);
+        $this->assertStringContainsString('<div class="form-group date is-invalid">', $result);
 
         $result = $this->Form->control('created', [
             'type' => 'time',
         ]);
-        $this->assertStringContainsString('<div class="form-group time is-invalid" role="group" aria-labelledby="created-group-label">', $result);
+        $this->assertStringContainsString('<div class="form-group time is-invalid">', $result);
 
         $result = $this->Form->control('created', [
             'type' => 'datetime',

--- a/tests/TestCase/View/Helper/FormHelper/DefaultAlign/FileControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/DefaultAlign/FileControlTest.php
@@ -75,6 +75,38 @@ class FileControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testDefaultAlignFileControlWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('file', [
+            'type' => 'file',
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group file']],
+                ['label' => [
+                    'class' => 'custom-label-class',
+                    'foo' => 'bar',
+                    'for' => 'file',
+                ]],
+                    'Custom Label',
+                '/label',
+                ['input' => [
+                    'type' => 'file',
+                    'name' => 'file',
+                    'id' => 'file',
+                    'class' => 'form-control-file',
+                ]],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testDefaultAlignFileControlWithHelp()
     {
         $this->Form->create($this->article);

--- a/tests/TestCase/View/Helper/FormHelper/DefaultAlign/FileCustomControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/DefaultAlign/FileCustomControlTest.php
@@ -84,6 +84,77 @@ class FileCustomControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testDefaultAlignCustomFileControlWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('file', [
+            'type' => 'file',
+            'custom' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group file']],
+                ['div' => ['class' => 'custom-file ']],
+                    ['input' => [
+                        'type' => 'file',
+                        'name' => 'file',
+                        'id' => 'file',
+                        'class' => 'custom-file-input',
+                    ]],
+                    ['label' => [
+                        'class' => 'custom-label-class custom-file-label',
+                        'foo' => 'bar',
+                        'for' => 'file',
+                    ]],
+                        'Custom Label',
+                    '/label',
+                 '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * Custom file control label templates are not backwards compatible,
+     * they will produce a duplicate `class` attribute.
+     */
+    public function testDefaultAlignCustomFileControlWithCustomLabelTemplateIsBackwardsCompatible()
+    {
+        $this->markTestIncomplete('Custom file control label templates are not backwards compatible');
+
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('file', [
+            'type' => 'file',
+            'custom' => true,
+            'templates' => [
+                'customFileLabel' =>
+                    '<label class="custom-file-label"{{attrs}} back="compat">{{text}}{{tooltip}}</label>',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group file']],
+                ['div' => ['class' => 'custom-file ']],
+                    ['input' => [
+                        'type' => 'file',
+                        'name' => 'file',
+                        'id' => 'file',
+                        'class' => 'custom-file-input',
+                    ]],
+                    ['label' => ['class' => 'custom-file-label', 'for' => 'file', 'back' => 'compact']],
+                        'File',
+                    '/label',
+                 '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result, true);
+    }
+
     public function testDefaultAlignCustomFileControlWithHelp()
     {
         $this->Form->create($this->article);

--- a/tests/TestCase/View/Helper/FormHelper/DefaultAlign/MultipleCheckboxControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/DefaultAlign/MultipleCheckboxControlTest.php
@@ -164,6 +164,123 @@ class MultipleCheckboxControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testDefaultAlignMultipleCheckboxControlWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group multicheckbox',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['label' => ['id' => 'users-group-label', 'class' => 'custom-label-class d-block', 'foo' => 'bar']],
+                    'Custom Label',
+                '/label',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'form-check']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-1',
+                        'value' => 1,
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-2',
+                        'value' => 2,
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignMultipleCheckboxControlWithCustomLabelTemplateIsBackwardsCompatible()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'templates' => [
+                'multicheckboxLabel' =>
+                    '<label id="{{groupId}}" class="d-block" back="compat">{{text}}{{tooltip}}</label>',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group multicheckbox',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['label' => ['id' => 'users-group-label', 'class' => 'd-block', 'back' => 'compat']],
+                    'Users',
+                '/label',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'form-check']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-1',
+                        'value' => 1,
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-2',
+                        'value' => 2,
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testDefaultAlignMultipleCheckboxControlWithHelp()
     {
         $this->Form->create($this->article);
@@ -694,6 +811,121 @@ class MultipleCheckboxControlTest extends AbstractFormHelperTest
             ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
                 ['label' => ['id' => 'users-group-label', 'class' => 'd-block']],
                     'Custom Label',
+                '/label',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-1',
+                        'value' => 1,
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-2',
+                        'value' => 2,
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignMultipleCheckboxControlInlineWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'inline' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['label' => ['id' => 'users-group-label', 'class' => 'custom-label-class d-block', 'foo' => 'bar']],
+                    'Custom Label',
+                '/label',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-1',
+                        'value' => 1,
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-2',
+                        'value' => 2,
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignMultipleCheckboxControlInlineWithCustomLabelTemplateIsBackwardsCompatible()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'inline' => true,
+            'templates' => [
+                'multicheckboxLabel' =>
+                    '<label id="{{groupId}}" class="d-block" back="compat">{{text}}{{tooltip}}</label>',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group multicheckbox',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['label' => ['id' => 'users-group-label', 'class' => 'd-block', 'back' => 'compat']],
+                    'Users',
                 '/label',
                 ['input' => [
                     'type' => 'hidden',

--- a/tests/TestCase/View/Helper/FormHelper/DefaultAlign/MultipleCheckboxCustomControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/DefaultAlign/MultipleCheckboxCustomControlTest.php
@@ -167,6 +167,121 @@ class MultipleCheckboxCustomControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testDefaultAlignCustomMultipleCheckboxControlWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'custom' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group multicheckbox',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['label' => ['id' => 'users-group-label', 'class' => 'custom-label-class d-block', 'foo' => 'bar']],
+                    'Custom Label',
+                '/label',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'custom-control custom-checkbox']],
+                    ['input' => [
+                        'class' => 'custom-control-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-1',
+                        'value' => 1,
+                    ]],
+                    ['label' => ['class' => 'custom-control-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'custom-control custom-checkbox']],
+                    ['input' => [
+                        'class' => 'custom-control-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-2',
+                        'value' => 2,
+                    ]],
+                    ['label' => ['class' => 'custom-control-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignCustomMultipleCheckboxControlWithCustomLabelTemplateIsBackwardsCompatible()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'custom' => true,
+            'templates' => [
+                'multicheckboxLabel' =>
+                    '<label id="{{groupId}}" class="d-block" back="compat">{{text}}{{tooltip}}</label>',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['label' => ['id' => 'users-group-label', 'class' => 'd-block', 'back' => 'compat']],
+                    'Users',
+                '/label',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'custom-control custom-checkbox']],
+                    ['input' => [
+                        'class' => 'custom-control-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-1',
+                        'value' => 1,
+                    ]],
+                    ['label' => ['class' => 'custom-control-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'custom-control custom-checkbox']],
+                    ['input' => [
+                        'class' => 'custom-control-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-2',
+                        'value' => 2,
+                    ]],
+                    ['label' => ['class' => 'custom-control-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testDefaultAlignCustomMultipleCheckboxControlWithHelp()
     {
         $this->Form->create($this->article);
@@ -613,6 +728,123 @@ class MultipleCheckboxCustomControlTest extends AbstractFormHelperTest
             ]],
                 ['label' => ['id' => 'users-group-label', 'class' => 'd-block']],
                     'Custom Label',
+                '/label',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'custom-control custom-checkbox custom-control-inline']],
+                    ['input' => [
+                        'class' => 'custom-control-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-1',
+                        'value' => 1,
+                    ]],
+                    ['label' => ['class' => 'custom-control-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'custom-control custom-checkbox custom-control-inline']],
+                    ['input' => [
+                        'class' => 'custom-control-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-2',
+                        'value' => 2,
+                    ]],
+                    ['label' => ['class' => 'custom-control-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignCustomMultipleCheckboxControlInlineWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'custom' => true,
+            'inline' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group multicheckbox',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['label' => ['id' => 'users-group-label', 'class' => 'custom-label-class d-block', 'foo' => 'bar']],
+                    'Custom Label',
+                '/label',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'custom-control custom-checkbox custom-control-inline']],
+                    ['input' => [
+                        'class' => 'custom-control-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-1',
+                        'value' => 1,
+                    ]],
+                    ['label' => ['class' => 'custom-control-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'custom-control custom-checkbox custom-control-inline']],
+                    ['input' => [
+                        'class' => 'custom-control-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-2',
+                        'value' => 2,
+                    ]],
+                    ['label' => ['class' => 'custom-control-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignCustomMultipleCheckboxControlInlineWithCustomLabelTemplateIsBackwardsCompatible()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'custom' => true,
+            'inline' => true,
+            'templates' => [
+                'multicheckboxLabel' =>
+                    '<label id="{{groupId}}" class="d-block" back="compat">{{text}}{{tooltip}}</label>',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group multicheckbox', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['label' => ['id' => 'users-group-label', 'class' => 'd-block', 'back' => 'compat']],
+                    'Users',
                 '/label',
                 ['input' => [
                     'type' => 'hidden',

--- a/tests/TestCase/View/Helper/FormHelper/DefaultAlign/RadioControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/DefaultAlign/RadioControlTest.php
@@ -156,6 +156,115 @@ class RadioControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testDefaultAlignRadioControlWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'type' => 'radio',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group radio', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['label' => ['id' => 'users-group-label', 'class' => 'custom-label-class d-block', 'foo' => 'bar']],
+                    'Custom Label',
+                '/label',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'form-check']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'radio',
+                        'name' => 'users',
+                        'id' => 'users-1',
+                        'value' => 1,
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'radio',
+                        'name' => 'users',
+                        'id' => 'users-2',
+                        'value' => 2,
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignRadioControlWithCustomLabelTemplateIsBackwardsCompatible()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'type' => 'radio',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'templates' => [
+                'radioLabel' =>
+                    '<label id="{{groupId}}" class="d-block" back="compat">{{text}}{{tooltip}}</label>',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group radio', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['label' => ['id' => 'users-group-label', 'class' => 'd-block', 'back' => 'compat']],
+                    'Users',
+                '/label',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'form-check']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'radio',
+                        'name' => 'users',
+                        'id' => 'users-1',
+                        'value' => 1,
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'radio',
+                        'name' => 'users',
+                        'id' => 'users-2',
+                        'value' => 2,
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testDefaultAlignRadioControlWithHelp()
     {
         $this->Form->create($this->article);
@@ -623,6 +732,117 @@ class RadioControlTest extends AbstractFormHelperTest
             ['div' => ['class' => 'form-group radio', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
                 ['label' => ['id' => 'users-group-label', 'class' => 'd-block']],
                     'Custom Label',
+                '/label',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'radio',
+                        'name' => 'users',
+                        'id' => 'users-1',
+                        'value' => 1,
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'radio',
+                        'name' => 'users',
+                        'id' => 'users-2',
+                        'value' => 2,
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignRadioControlInlineWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'type' => 'radio',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'inline' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group radio', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['label' => ['id' => 'users-group-label', 'class' => 'custom-label-class d-block', 'foo' => 'bar']],
+                    'Custom Label',
+                '/label',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'radio',
+                        'name' => 'users',
+                        'id' => 'users-1',
+                        'value' => 1,
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'radio',
+                        'name' => 'users',
+                        'id' => 'users-2',
+                        'value' => 2,
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignRadioControlInlineWithCustomLabelTemplateIsBackwardsCompatible()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'type' => 'radio',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'inline' => true,
+            'templates' => [
+                'radioLabel' =>
+                    '<label id="{{groupId}}" class="d-block" back="compat">{{text}}{{tooltip}}</label>',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group radio', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['label' => ['id' => 'users-group-label', 'class' => 'd-block', 'back' => 'compat']],
+                    'Users',
                 '/label',
                 ['input' => [
                     'type' => 'hidden',

--- a/tests/TestCase/View/Helper/FormHelper/DefaultAlign/RadioCustomControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/DefaultAlign/RadioCustomControlTest.php
@@ -159,6 +159,117 @@ class RadioCustomControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testDefaultAlignCustomRadioControlWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'type' => 'radio',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'custom' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group radio', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['label' => ['id' => 'users-group-label', 'class' => 'custom-label-class d-block', 'foo' => 'bar']],
+                    'Custom Label',
+                '/label',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'custom-control custom-radio']],
+                    ['input' => [
+                        'class' => 'custom-control-input',
+                        'type' => 'radio',
+                        'name' => 'users',
+                        'id' => 'users-1',
+                        'value' => 1,
+                    ]],
+                    ['label' => ['class' => 'custom-control-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'custom-control custom-radio']],
+                    ['input' => [
+                        'class' => 'custom-control-input',
+                        'type' => 'radio',
+                        'name' => 'users',
+                        'id' => 'users-2',
+                        'value' => 2,
+                    ]],
+                    ['label' => ['class' => 'custom-control-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignCustomRadioControlWithCustomLabelTemplateIsBackwardsCompatible()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'type' => 'radio',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'custom' => true,
+            'templates' => [
+                'radioLabel' =>
+                    '<label id="{{groupId}}" class="d-block" back="compat">{{text}}{{tooltip}}</label>',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group radio', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['label' => ['id' => 'users-group-label', 'class' => 'd-block', 'back' => 'compat']],
+                    'Users',
+                '/label',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'custom-control custom-radio']],
+                    ['input' => [
+                        'class' => 'custom-control-input',
+                        'type' => 'radio',
+                        'name' => 'users',
+                        'id' => 'users-1',
+                        'value' => 1,
+                    ]],
+                    ['label' => ['class' => 'custom-control-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'custom-control custom-radio']],
+                    ['input' => [
+                        'class' => 'custom-control-input',
+                        'type' => 'radio',
+                        'name' => 'users',
+                        'id' => 'users-2',
+                        'value' => 2,
+                    ]],
+                    ['label' => ['class' => 'custom-control-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testDefaultAlignCustomRadioControlWithHelp()
     {
         $this->Form->create($this->article);
@@ -584,6 +695,119 @@ class RadioCustomControlTest extends AbstractFormHelperTest
             ['div' => ['class' => 'form-group radio', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
                 ['label' => ['id' => 'users-group-label', 'class' => 'd-block']],
                     'Custom Label',
+                '/label',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'custom-control custom-radio custom-control-inline']],
+                    ['input' => [
+                        'class' => 'custom-control-input',
+                        'type' => 'radio',
+                        'name' => 'users',
+                        'id' => 'users-1',
+                        'value' => 1,
+                    ]],
+                    ['label' => ['class' => 'custom-control-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'custom-control custom-radio custom-control-inline']],
+                    ['input' => [
+                        'class' => 'custom-control-input',
+                        'type' => 'radio',
+                        'name' => 'users',
+                        'id' => 'users-2',
+                        'value' => 2,
+                    ]],
+                    ['label' => ['class' => 'custom-control-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignCustomRadioControlInlineWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'type' => 'radio',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'custom' => true,
+            'inline' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group radio', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['label' => ['id' => 'users-group-label', 'class' => 'custom-label-class d-block', 'foo' => 'bar']],
+                    'Custom Label',
+                '/label',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'custom-control custom-radio custom-control-inline']],
+                    ['input' => [
+                        'class' => 'custom-control-input',
+                        'type' => 'radio',
+                        'name' => 'users',
+                        'id' => 'users-1',
+                        'value' => 1,
+                    ]],
+                    ['label' => ['class' => 'custom-control-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'custom-control custom-radio custom-control-inline']],
+                    ['input' => [
+                        'class' => 'custom-control-input',
+                        'type' => 'radio',
+                        'name' => 'users',
+                        'id' => 'users-2',
+                        'value' => 2,
+                    ]],
+                    ['label' => ['class' => 'custom-control-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignCustomRadioControlInlineWithCustomLabelTemplateIsBackwardsCompatible()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'type' => 'radio',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'custom' => true,
+            'inline' => true,
+            'templates' => [
+                'radioLabel' =>
+                    '<label id="{{groupId}}" class="d-block" back="compat">{{text}}{{tooltip}}</label>',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group radio', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['label' => ['id' => 'users-group-label', 'class' => 'd-block', 'back' => 'compat']],
+                    'Users',
                 '/label',
                 ['input' => [
                     'type' => 'hidden',

--- a/tests/TestCase/View/Helper/FormHelper/DefaultAlign/RangeControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/DefaultAlign/RangeControlTest.php
@@ -93,6 +93,40 @@ class RangeControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testDefaultAlignRangeControlWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('height', [
+            'type' => 'range',
+            'min' => 0,
+            'max' => 10,
+            'step' => 1,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            'div' => ['class' => 'form-group range'],
+                ['label' => ['class' => 'custom-label-class', 'foo' => 'bar', 'for' => 'height']],
+                    'Custom Label',
+                '/label',
+                'input' => [
+                    'type' => 'range',
+                    'name' => 'height',
+                    'min' => 0,
+                    'max' => 10,
+                    'step' => 1,
+                    'id' => 'height',
+                    'class' => 'form-control',
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testDefaultAlignRangeControlWithHelp()
     {
         $this->Form->create($this->article);

--- a/tests/TestCase/View/Helper/FormHelper/DefaultAlign/RangeCustomControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/DefaultAlign/RangeCustomControlTest.php
@@ -96,6 +96,41 @@ class RangeCustomControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testDefaultAlignCustomRangeControlWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('height', [
+            'type' => 'range',
+            'min' => 0,
+            'max' => 10,
+            'step' => 1,
+            'custom' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            'div' => ['class' => 'form-group range'],
+                ['label' => ['class' => 'custom-label-class', 'foo' => 'bar', 'for' => 'height']],
+                    'Custom Label',
+                '/label',
+                'input' => [
+                    'type' => 'range',
+                    'name' => 'height',
+                    'min' => 0,
+                    'max' => 10,
+                    'step' => 1,
+                    'id' => 'height',
+                    'class' => 'custom-range',
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testDefaultAlignCustomRangeControlWithHelp()
     {
         $this->Form->create($this->article);

--- a/tests/TestCase/View/Helper/FormHelper/DefaultAlign/SelectCustomControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/DefaultAlign/SelectCustomControlTest.php
@@ -96,6 +96,41 @@ class SelectCustomControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testDefaultAlignCustomSelectControlWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'type' => 'select',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'custom' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group select']],
+                ['label' => ['for' => 'users', 'class' => 'custom-label-class', 'foo' => 'bar']],
+                    'Custom Label',
+                '/label',
+                ['select' => ['name' => 'users', 'id' => 'users', 'class' => 'custom-select']],
+                    ['option' => ['value' => '1']],
+                        'option 1',
+                    '/option',
+                    ['option' => ['value' => '2']],
+                        'option 2',
+                    '/option',
+                '/select',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testDefaultAlignCustomSelectControlWithHelp()
     {
         $this->Form->create($this->article);

--- a/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/CheckboxControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/CheckboxControlTest.php
@@ -126,6 +126,51 @@ class CheckboxControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testHorizontalAlignCheckboxControlWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('users', [
+            'type' => 'checkbox',
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group row checkbox']],
+                ['div' => ['class' => 'offset-sm-5 col-sm-7']],
+                    ['div' => ['class' => 'form-check']],
+                        ['input' => [
+                            'type' => 'hidden',
+                            'name' => 'users',
+                            'value' => 0,
+                        ]],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users',
+                            'id' => 'users',
+                            'value' => 1,
+                        ]],
+                        ['label' => ['class' => 'custom-label-class form-check-label', 'foo' => 'bar', 'for' => 'users']],
+                            'Custom Label',
+                        '/label',
+                    '/div',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testHorizontalAlignCheckboxControlWithHelp()
     {
         $this->Form->create($this->article, [
@@ -662,6 +707,52 @@ class CheckboxControlTest extends AbstractFormHelperTest
                             'value' => 1,
                         ]],
                         ['label' => ['class' => 'form-check-label', 'for' => 'users']],
+                            'Custom Label',
+                        '/label',
+                    '/div',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignCheckboxControlInlineWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('users', [
+            'type' => 'checkbox',
+            'inline' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group row checkbox']],
+                ['div' => ['class' => 'offset-sm-5 col-sm-7']],
+                    ['div' => ['class' => 'form-check']],
+                        ['input' => [
+                            'type' => 'hidden',
+                            'name' => 'users',
+                            'value' => 0,
+                        ]],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users',
+                            'id' => 'users',
+                            'value' => 1,
+                        ]],
+                        ['label' => ['class' => 'custom-label-class form-check-label', 'foo' => 'bar', 'for' => 'users']],
                             'Custom Label',
                         '/label',
                     '/div',

--- a/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/CheckboxCustomControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/CheckboxCustomControlTest.php
@@ -129,6 +129,52 @@ class CheckboxCustomControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testHorizontalAlignCustomCheckboxControlWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('users', [
+            'type' => 'checkbox',
+            'custom' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            'div' => ['class' => 'form-group row checkbox'],
+                ['div' => ['class' => 'offset-sm-5 col-sm-7']],
+                    ['div' => ['class' => 'custom-control custom-checkbox']],
+                        ['input' => [
+                            'type' => 'hidden',
+                            'name' => 'users',
+                            'value' => 0,
+                        ]],
+                        ['input' => [
+                            'type' => 'checkbox',
+                            'name' => 'users',
+                            'value' => '1',
+                            'id' => 'users',
+                            'class' => 'custom-control-input',
+                        ]],
+                        ['label' => ['class' => 'custom-label-class custom-control-label', 'foo' => 'bar', 'for' => 'users']],
+                            'Custom Label',
+                        '/label',
+                    '/div',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testHorizontalAlignCustomCheckboxControlWithHelp()
     {
         $this->Form->create($this->article, [
@@ -537,6 +583,53 @@ class CheckboxCustomControlTest extends AbstractFormHelperTest
                             'class' => 'custom-control-input',
                         ]],
                         ['label' => ['class' => 'custom-control-label', 'for' => 'users']],
+                            'Custom Label',
+                        '/label',
+                    '/div',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignCustomCheckboxControlInlineWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('users', [
+            'type' => 'checkbox',
+            'custom' => true,
+            'inline' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            'div' => ['class' => 'form-group row checkbox'],
+                ['div' => ['class' => 'offset-sm-5 col-sm-7']],
+                    ['div' => ['class' => 'custom-control custom-checkbox']],
+                        ['input' => [
+                            'type' => 'hidden',
+                            'name' => 'users',
+                            'value' => 0,
+                        ]],
+                        ['input' => [
+                            'type' => 'checkbox',
+                            'name' => 'users',
+                            'value' => '1',
+                            'id' => 'users',
+                            'class' => 'custom-control-input',
+                        ]],
+                        ['label' => ['class' => 'custom-label-class custom-control-label', 'foo' => 'bar', 'for' => 'users']],
                             'Custom Label',
                         '/label',
                     '/div',

--- a/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/DateTimeControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/DateTimeControlTest.php
@@ -26,7 +26,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
         ]);
         $expected = [
             ['div' => ['class' => 'form-group row datetime-local', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5']],
+                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5', 'for' => 'created']],
                     'Created',
                 '/label',
                 ['div' => ['class' => 'col-sm-7']],
@@ -97,8 +97,97 @@ class DateTimeControlTest extends AbstractFormHelperTest
         ]);
         $expected = [
             ['div' => ['class' => 'form-group row datetime-local', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5']],
+                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5', 'for' => 'created']],
                     'Custom Label',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    'input' => [
+                        'type' => 'datetime-local',
+                        'name' => 'created',
+                        'id' => 'created',
+                        'class' => 'form-control',
+                        'value' => $now->format('Y-m-d H:i:s'),
+                    ],
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignDateTimeControlWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $now = new \DateTime('now');
+
+        $result = $this->Form->control('created', [
+            'type' => 'datetime-local',
+            'value' => $now->format('Y-m-d H:i:s'),
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group row datetime-local', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
+                ['label' => ['id' => 'created-group-label', 'class' => 'custom-label-class col-form-label col-sm-5', 'foo' => 'bar', 'for' => 'created']],
+                    'Custom Label',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    'input' => [
+                        'type' => 'datetime-local',
+                        'name' => 'created',
+                        'id' => 'created',
+                        'class' => 'form-control',
+                        'value' => $now->format('Y-m-d H:i:s'),
+                    ],
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignDateTimeControlWithCustomLabelTemplateIsBackwardsCompatible()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $now = new \DateTime('now');
+
+        $result = $this->Form->control('created', [
+            'type' => 'datetime-local',
+            'value' => $now->format('Y-m-d H:i:s'),
+            'templates' => [
+                'datetimeLabel' =>
+                    '<label id="{{groupId}}" class="col-form-label %s" back="compat">{{text}}{{tooltip}}</label>',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group row datetime-local',
+                'role' => 'group',
+                'aria-labelledby' => 'created-group-label',
+            ]],
+                ['label' => [
+                    'id' => 'created-group-label',
+                    'class' => 'col-form-label %s',
+                    'back' => 'compat',
+                ]],
+                    'Created',
                 '/label',
                 ['div' => ['class' => 'col-sm-7']],
                     'input' => [
@@ -134,7 +223,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
         ]);
         $expected = [
             ['div' => ['class' => 'form-group row time', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5']],
+                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5', 'for' => 'created']],
                     'Created',
                 '/label',
                 ['div' => ['class' => 'col-sm-7']],
@@ -178,7 +267,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
         ]);
         $expected = [
             ['div' => ['class' => 'form-group row time', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5']],
+                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5', 'for' => 'created']],
                     'Created',
                 '/label',
                 ['div' => ['class' => 'col-sm-7']],
@@ -219,7 +308,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
         ]);
         $expected = [
             ['div' => ['class' => 'form-group row time', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5']],
+                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5', 'for' => 'created']],
                     'Created ',
                     'span' => [
                         'data-toggle' => 'tooltip',
@@ -269,7 +358,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
                 'role' => 'group',
                 'aria-labelledby' => 'created-group-label',
             ]],
-                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5']],
+                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5', 'for' => 'created']],
                     'Created',
                 '/label',
                 ['div' => ['class' => 'col-sm-7']],
@@ -317,7 +406,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
                 'role' => 'group',
                 'aria-labelledby' => 'created-group-label',
             ]],
-                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5']],
+                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5', 'for' => 'created']],
                     'Created',
                 '/label',
                 ['div' => ['class' => 'col-sm-7']],
@@ -365,7 +454,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
                 'role' => 'group',
                 'aria-labelledby' => 'created-group-label',
             ]],
-                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5']],
+                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5', 'for' => 'created']],
                     'Created',
                 '/label',
                 ['div' => ['class' => 'col-sm-7']],
@@ -404,7 +493,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
         ]);
         $expected = [
             ['div' => ['class' => 'form-group row date', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5']],
+                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5', 'for' => 'created']],
                     'Created',
                 '/label',
                 ['div' => ['class' => 'col-sm-7']],
@@ -440,7 +529,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
         ]);
         $expected = [
             ['div' => ['class' => 'form-group row time', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5']],
+                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5', 'for' => 'created']],
                     'Created',
                 '/label',
                 ['div' => ['class' => 'col-sm-7']],

--- a/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/DateTimeControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/DateTimeControlTest.php
@@ -25,8 +25,8 @@ class DateTimeControlTest extends AbstractFormHelperTest
             'value' => $now->format('Y-m-d H:i:s'),
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group row datetime-local', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5', 'for' => 'created']],
+            ['div' => ['class' => 'form-group row datetime-local']],
+                ['label' => ['class' => 'col-form-label col-sm-5', 'for' => 'created']],
                     'Created',
                 '/label',
                 ['div' => ['class' => 'col-sm-7']],
@@ -62,7 +62,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
             'label' => false,
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group row datetime-local', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
+            ['div' => ['class' => 'form-group row datetime-local']],
                 ['div' => ['class' => 'col-sm-7']],
                     'input' => [
                         'type' => 'datetime-local',
@@ -96,8 +96,8 @@ class DateTimeControlTest extends AbstractFormHelperTest
             'label' => 'Custom Label',
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group row datetime-local', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5', 'for' => 'created']],
+            ['div' => ['class' => 'form-group row datetime-local']],
+                ['label' => ['class' => 'col-form-label col-sm-5', 'for' => 'created']],
                     'Custom Label',
                 '/label',
                 ['div' => ['class' => 'col-sm-7']],
@@ -137,8 +137,8 @@ class DateTimeControlTest extends AbstractFormHelperTest
             ],
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group row datetime-local', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['label' => ['id' => 'created-group-label', 'class' => 'custom-label-class col-form-label col-sm-5', 'foo' => 'bar', 'for' => 'created']],
+            ['div' => ['class' => 'form-group row datetime-local']],
+                ['label' => ['class' => 'custom-label-class col-form-label col-sm-5', 'foo' => 'bar', 'for' => 'created']],
                     'Custom Label',
                 '/label',
                 ['div' => ['class' => 'col-sm-7']],
@@ -172,6 +172,9 @@ class DateTimeControlTest extends AbstractFormHelperTest
             'type' => 'datetime-local',
             'value' => $now->format('Y-m-d H:i:s'),
             'templates' => [
+                'datetimeContainer' =>
+                    '<div{{containerAttrs}} class="{{containerClass}}form-group row {{type}}{{required}}" role="group" ' .
+                        'aria-labelledby="{{groupId}}">{{content}}</div>',
                 'datetimeLabel' =>
                     '<label id="{{groupId}}" class="col-form-label %s" back="compat">{{text}}{{tooltip}}</label>',
             ],
@@ -222,8 +225,8 @@ class DateTimeControlTest extends AbstractFormHelperTest
             'help' => 'Help text',
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group row time', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5', 'for' => 'created']],
+            ['div' => ['class' => 'form-group row time']],
+                ['label' => ['class' => 'col-form-label col-sm-5', 'for' => 'created']],
                     'Created',
                 '/label',
                 ['div' => ['class' => 'col-sm-7']],
@@ -266,8 +269,8 @@ class DateTimeControlTest extends AbstractFormHelperTest
             ],
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group row time', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5', 'for' => 'created']],
+            ['div' => ['class' => 'form-group row time']],
+                ['label' => ['class' => 'col-form-label col-sm-5', 'for' => 'created']],
                     'Created',
                 '/label',
                 ['div' => ['class' => 'col-sm-7']],
@@ -307,8 +310,8 @@ class DateTimeControlTest extends AbstractFormHelperTest
             'tooltip' => 'Tooltip text',
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group row time', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5', 'for' => 'created']],
+            ['div' => ['class' => 'form-group row time']],
+                ['label' => ['class' => 'col-form-label col-sm-5', 'for' => 'created']],
                     'Created ',
                     'span' => [
                         'data-toggle' => 'tooltip',
@@ -355,10 +358,8 @@ class DateTimeControlTest extends AbstractFormHelperTest
         $expected = [
             ['div' => [
                 'class' => 'form-group row datetime-local is-invalid',
-                'role' => 'group',
-                'aria-labelledby' => 'created-group-label',
             ]],
-                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5', 'for' => 'created']],
+                ['label' => ['class' => 'col-form-label col-sm-5', 'for' => 'created']],
                     'Created',
                 '/label',
                 ['div' => ['class' => 'col-sm-7']],
@@ -403,10 +404,8 @@ class DateTimeControlTest extends AbstractFormHelperTest
             ['div' => [
                 'attribute' => 'container-attribute',
                 'class' => 'container-class form-group row datetime-local',
-                'role' => 'group',
-                'aria-labelledby' => 'created-group-label',
             ]],
-                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5', 'for' => 'created']],
+                ['label' => ['class' => 'col-form-label col-sm-5', 'for' => 'created']],
                     'Created',
                 '/label',
                 ['div' => ['class' => 'col-sm-7']],
@@ -451,10 +450,8 @@ class DateTimeControlTest extends AbstractFormHelperTest
             ['div' => [
                 'attribute' => 'container-attribute',
                 'class' => 'container-class form-group row datetime-local is-invalid',
-                'role' => 'group',
-                'aria-labelledby' => 'created-group-label',
             ]],
-                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5', 'for' => 'created']],
+                ['label' => ['class' => 'col-form-label col-sm-5', 'for' => 'created']],
                     'Created',
                 '/label',
                 ['div' => ['class' => 'col-sm-7']],
@@ -492,8 +489,8 @@ class DateTimeControlTest extends AbstractFormHelperTest
             'value' => $now,
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group row date', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5', 'for' => 'created']],
+            ['div' => ['class' => 'form-group row date']],
+                ['label' => ['class' => 'col-form-label col-sm-5', 'for' => 'created']],
                     'Created',
                 '/label',
                 ['div' => ['class' => 'col-sm-7']],
@@ -528,8 +525,8 @@ class DateTimeControlTest extends AbstractFormHelperTest
             'value' => $now,
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group row time', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['label' => ['id' => 'created-group-label', 'class' => 'col-form-label col-sm-5', 'for' => 'created']],
+            ['div' => ['class' => 'form-group row time']],
+                ['label' => ['class' => 'col-form-label col-sm-5', 'for' => 'created']],
                     'Created',
                 '/label',
                 ['div' => ['class' => 'col-sm-7']],
@@ -561,17 +558,17 @@ class DateTimeControlTest extends AbstractFormHelperTest
         $result = $this->Form->control('created', [
             'type' => 'datetime',
         ]);
-        $this->assertStringContainsString('<div class="form-group row datetime" role="group" aria-labelledby="created-group-label">', $result);
+        $this->assertStringContainsString('<div class="form-group row datetime">', $result);
 
         $result = $this->Form->control('created', [
             'type' => 'date',
         ]);
-        $this->assertStringContainsString('<div class="form-group row date" role="group" aria-labelledby="created-group-label">', $result);
+        $this->assertStringContainsString('<div class="form-group row date">', $result);
 
         $result = $this->Form->control('created', [
             'type' => 'time',
         ]);
-        $this->assertStringContainsString('<div class="form-group row time" role="group" aria-labelledby="created-group-label">', $result);
+        $this->assertStringContainsString('<div class="form-group row time">', $result);
 
         $this->Form->setTemplates([
             'datetimeContainer' => '<div class="custom datetimeContainer {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
@@ -613,17 +610,17 @@ class DateTimeControlTest extends AbstractFormHelperTest
         $result = $this->Form->control('created', [
             'type' => 'datetime',
         ]);
-        $this->assertStringContainsString('<div class="form-group row datetime is-invalid" role="group" aria-labelledby="created-group-label">', $result);
+        $this->assertStringContainsString('<div class="form-group row datetime is-invalid">', $result);
 
         $result = $this->Form->control('created', [
             'type' => 'date',
         ]);
-        $this->assertStringContainsString('<div class="form-group row date is-invalid" role="group" aria-labelledby="created-group-label">', $result);
+        $this->assertStringContainsString('<div class="form-group row date is-invalid">', $result);
 
         $result = $this->Form->control('created', [
             'type' => 'time',
         ]);
-        $this->assertStringContainsString('<div class="form-group row time is-invalid" role="group" aria-labelledby="created-group-label">', $result);
+        $this->assertStringContainsString('<div class="form-group row time is-invalid">', $result);
 
         $result = $this->Form->control('created', [
             'type' => 'datetime',

--- a/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/FileControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/FileControlTest.php
@@ -102,6 +102,85 @@ class FileControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testHorizontalAlignFileControlWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('file', [
+            'type' => 'file',
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group row file']],
+                ['label' => ['class' => 'custom-label-class col-form-label pt-1 col-sm-5', 'foo' => 'bar', 'for' => 'file']],
+                    'Custom Label',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    ['input' => [
+                        'type' => 'file',
+                        'name' => 'file',
+                        'id' => 'file',
+                        'class' => 'form-control-file',
+                    ]],
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * Horizontal file control label templates are not backwards compatible,
+     * they will produce a duplicate `class` attribute.
+     */
+    public function testHorizontalAlignFileControlWithCustomLabelTemplateIsBackwardsCompatible()
+    {
+        $this->markTestIncomplete('Horizontal file control label templates are not backwards compatible');
+
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('file', [
+            'type' => 'file',
+            'templates' => [
+                'fileLabel' =>
+                    '<label class="col-form-label pt-1 %s"{{attrs}} back="compat">{{text}}{{tooltip}}</label>',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group row file']],
+                ['label' => ['class' => 'col-form-label pt-1 %s', 'for' => 'file', 'back' => 'compat']],
+                    'File',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    ['input' => [
+                        'type' => 'file',
+                        'name' => 'file',
+                        'id' => 'file',
+                        'class' => 'form-control-file',
+                    ]],
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testHorizontalAlignFileControlWithHelp()
     {
         $this->Form->create($this->article, [

--- a/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/FileCustomControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/FileCustomControlTest.php
@@ -111,6 +111,91 @@ class FileCustomControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testHorizontalAlignCustomFileControlWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('file', [
+            'type' => 'file',
+            'custom' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group row file']],
+                ['div' => ['class' => 'offset-sm-5 col-sm-7']],
+                    ['div' => ['class' => 'custom-file ']],
+                        ['input' => [
+                            'type' => 'file',
+                            'name' => 'file',
+                            'id' => 'file',
+                            'class' => 'custom-file-input',
+                        ]],
+                        ['label' => ['class' => 'custom-label-class custom-file-label', 'foo' => 'bar', 'for' => 'file']],
+                            'Custom Label',
+                        '/label',
+                    '/div',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * Horizontal custom file control label templates are not backwards compatible,
+     * they will produce a duplicate `class` attribute.
+     */
+    public function testHorizontalAlignCustomFileControlWithCustomLabelTemplateIsBackwardsCompatible()
+    {
+        $this->markTestIncomplete('Horizontal custom file control label templates are not backwards compatible');
+
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('file', [
+            'type' => 'file',
+            'custom' => true,
+            'templates' => [
+                'customFileLabel' =>
+                    '<label class="custom-file-label"{{attrs}} back="compat">{{text}}{{tooltip}}</label>',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group row file']],
+                ['div' => ['class' => 'offset-sm-5 col-sm-7']],
+                    ['div' => ['class' => 'custom-file ']],
+                        ['input' => [
+                            'type' => 'file',
+                            'name' => 'file',
+                            'id' => 'file',
+                            'class' => 'custom-file-input',
+                        ]],
+                        ['label' => ['class' => 'custom-file-label', 'for' => 'file', 'back' => 'compact']],
+                            'File',
+                        '/label',
+                    '/div',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testHorizontalAlignCustomFileControlWithHelp()
     {
         $this->Form->create($this->article, [

--- a/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/MultipleCheckboxControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/MultipleCheckboxControlTest.php
@@ -191,6 +191,145 @@ class MultipleCheckboxControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testHorizontalAlignMultipleCheckboxControlWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group row multicheckbox',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['label' => ['id' => 'users-group-label', 'class' => 'custom-label-class col-form-label d-block pt-0 col-sm-5', 'foo' => 'bar']],
+                    'Custom Label',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    ['input' => [
+                        'type' => 'hidden',
+                        'name' => 'users',
+                        'value' => '',
+                    ]],
+                    ['div' => ['class' => 'form-check']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-1',
+                            'value' => 1,
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                            'option 1',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'form-check']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-2',
+                            'value' => 2,
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                            'option 2',
+                        '/label',
+                    '/div',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignMultipleCheckboxControlWithCustomLabelTemplateIsBackwardsCompatible()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+            'templates' => [
+                'multicheckboxLabel' =>
+                    '<label id="{{groupId}}" class="col-form-label d-block pt-0 %s" back="compat">{{text}}{{tooltip}}</label>',
+            ],
+        ]);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group row multicheckbox',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['label' => [
+                    'id' => 'users-group-label',
+                    'class' => 'col-form-label d-block pt-0 %s',
+                    'back' => 'compat',
+                ]],
+                    'Users',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    ['input' => [
+                        'type' => 'hidden',
+                        'name' => 'users',
+                        'value' => '',
+                    ]],
+                    ['div' => ['class' => 'form-check']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-1',
+                            'value' => 1,
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                            'option 1',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'form-check']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-2',
+                            'value' => 2,
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                            'option 2',
+                        '/label',
+                    '/div',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testHorizontalAlignMultipleCheckboxControlWithHelp()
     {
         $this->Form->create($this->article, [
@@ -834,6 +973,147 @@ class MultipleCheckboxControlTest extends AbstractFormHelperTest
             ]],
                 ['label' => ['id' => 'users-group-label', 'class' => 'col-form-label d-block pt-0 col-sm-5']],
                     'Custom Label',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    ['input' => [
+                        'type' => 'hidden',
+                        'name' => 'users',
+                        'value' => '',
+                    ]],
+                    ['div' => ['class' => 'form-check form-check-inline']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-1',
+                            'value' => 1,
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                            'option 1',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'form-check form-check-inline']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-2',
+                            'value' => 2,
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                            'option 2',
+                        '/label',
+                    '/div',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignMultipleCheckboxControlInlineWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'inline' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group row multicheckbox',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['label' => ['id' => 'users-group-label', 'class' => 'custom-label-class col-form-label d-block pt-0 col-sm-5', 'foo' => 'bar']],
+                    'Custom Label',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    ['input' => [
+                        'type' => 'hidden',
+                        'name' => 'users',
+                        'value' => '',
+                    ]],
+                    ['div' => ['class' => 'form-check form-check-inline']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-1',
+                            'value' => 1,
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                            'option 1',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'form-check form-check-inline']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-2',
+                            'value' => 2,
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                            'option 2',
+                        '/label',
+                    '/div',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignMultipleCheckboxControlInlineWithCustomLabelTemplateIsBackwardsCompatible()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'inline' => true,
+            'templates' => [
+                'multicheckboxLabel' =>
+                    '<label id="{{groupId}}" class="col-form-label d-block pt-0 %s" back="compat">{{text}}{{tooltip}}</label>',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group row multicheckbox',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['label' => [
+                    'id' => 'users-group-label',
+                    'class' => 'col-form-label d-block pt-0 %s',
+                    'back' => 'compat',
+                ]],
+                    'Users',
                 '/label',
                 ['div' => ['class' => 'col-sm-7']],
                     ['input' => [

--- a/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/MultipleCheckboxCustomControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/MultipleCheckboxCustomControlTest.php
@@ -194,6 +194,147 @@ class MultipleCheckboxCustomControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testHorizontalAlignCustomMultipleCheckboxControlWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'custom' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group row multicheckbox',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['label' => ['id' => 'users-group-label', 'class' => 'custom-label-class col-form-label d-block pt-0 col-sm-5', 'foo' => 'bar']],
+                    'Custom Label',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    ['input' => [
+                        'type' => 'hidden',
+                        'name' => 'users',
+                        'value' => '',
+                    ]],
+                    ['div' => ['class' => 'custom-control custom-checkbox']],
+                        ['input' => [
+                            'class' => 'custom-control-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-1',
+                            'value' => 1,
+                        ]],
+                        ['label' => ['class' => 'custom-control-label', 'for' => 'users-1']],
+                            'option 1',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'custom-control custom-checkbox']],
+                        ['input' => [
+                            'class' => 'custom-control-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-2',
+                            'value' => 2,
+                        ]],
+                        ['label' => ['class' => 'custom-control-label', 'for' => 'users-2']],
+                            'option 2',
+                        '/label',
+                    '/div',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignCustomMultipleCheckboxControlWithCustomLabelTemplateIsBackwardsCompatible()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'custom' => true,
+            'templates' => [
+                'multicheckboxLabel' =>
+                    '<label id="{{groupId}}" class="col-form-label d-block pt-0 %s" back="compat">{{text}}{{tooltip}}</label>',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group row multicheckbox',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['label' => [
+                    'id' => 'users-group-label',
+                    'class' => 'col-form-label d-block pt-0 %s',
+                    'back' => 'compat',
+                ]],
+                    'Users',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    ['input' => [
+                        'type' => 'hidden',
+                        'name' => 'users',
+                        'value' => '',
+                    ]],
+                    ['div' => ['class' => 'custom-control custom-checkbox']],
+                        ['input' => [
+                            'class' => 'custom-control-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-1',
+                            'value' => 1,
+                        ]],
+                        ['label' => ['class' => 'custom-control-label', 'for' => 'users-1']],
+                            'option 1',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'custom-control custom-checkbox']],
+                        ['input' => [
+                            'class' => 'custom-control-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-2',
+                            'value' => 2,
+                        ]],
+                        ['label' => ['class' => 'custom-control-label', 'for' => 'users-2']],
+                            'option 2',
+                        '/label',
+                    '/div',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testHorizontalAlignCustomMultipleCheckboxControlWithHelp()
     {
         $this->Form->create($this->article, [
@@ -713,6 +854,149 @@ class MultipleCheckboxCustomControlTest extends AbstractFormHelperTest
             ]],
                 ['label' => ['id' => 'users-group-label', 'class' => 'col-form-label d-block pt-0 col-sm-5']],
                     'Custom Label',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    ['input' => [
+                        'type' => 'hidden',
+                        'name' => 'users',
+                        'value' => '',
+                    ]],
+                    ['div' => ['class' => 'custom-control custom-checkbox custom-control-inline']],
+                        ['input' => [
+                            'class' => 'custom-control-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-1',
+                            'value' => 1,
+                        ]],
+                        ['label' => ['class' => 'custom-control-label', 'for' => 'users-1']],
+                            'option 1',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'custom-control custom-checkbox custom-control-inline']],
+                        ['input' => [
+                            'class' => 'custom-control-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-2',
+                            'value' => 2,
+                        ]],
+                        ['label' => ['class' => 'custom-control-label', 'for' => 'users-2']],
+                            'option 2',
+                        '/label',
+                    '/div',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignCustomMultipleCheckboxControlInlineWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'custom' => true,
+            'inline' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group row multicheckbox',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['label' => ['id' => 'users-group-label', 'class' => 'custom-label-class col-form-label d-block pt-0 col-sm-5', 'foo' => 'bar']],
+                    'Custom Label',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    ['input' => [
+                        'type' => 'hidden',
+                        'name' => 'users',
+                        'value' => '',
+                    ]],
+                    ['div' => ['class' => 'custom-control custom-checkbox custom-control-inline']],
+                        ['input' => [
+                            'class' => 'custom-control-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-1',
+                            'value' => 1,
+                        ]],
+                        ['label' => ['class' => 'custom-control-label', 'for' => 'users-1']],
+                            'option 1',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'custom-control custom-checkbox custom-control-inline']],
+                        ['input' => [
+                            'class' => 'custom-control-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-2',
+                            'value' => 2,
+                        ]],
+                        ['label' => ['class' => 'custom-control-label', 'for' => 'users-2']],
+                            'option 2',
+                        '/label',
+                    '/div',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignCustomMultipleCheckboxControlInlineWithCustomLabelTemplateIsBackwardsCompatible()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'custom' => true,
+            'inline' => true,
+            'templates' => [
+                'multicheckboxLabel' =>
+                    '<label id="{{groupId}}" class="col-form-label d-block pt-0 %s" back="compat">{{text}}{{tooltip}}</label>',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group row multicheckbox',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['label' => [
+                    'id' => 'users-group-label',
+                    'class' => 'col-form-label d-block pt-0 %s',
+                    'back' => 'compat',
+                ]],
+                    'Users',
                 '/label',
                 ['div' => ['class' => 'col-sm-7']],
                     ['input' => [

--- a/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/RadioControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/RadioControlTest.php
@@ -183,6 +183,141 @@ class RadioControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testHorizontalAlignRadioControlWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('users', [
+            'type' => 'radio',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group row radio', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['label' => ['id' => 'users-group-label', 'class' => 'custom-label-class col-form-label d-block pt-0 col-sm-5', 'foo' => 'bar']],
+                    'Custom Label',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    ['input' => [
+                        'type' => 'hidden',
+                        'name' => 'users',
+                        'value' => '',
+                    ]],
+                    ['div' => ['class' => 'form-check']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'radio',
+                            'name' => 'users',
+                            'id' => 'users-1',
+                            'value' => 1,
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                            'option 1',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'form-check']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'radio',
+                            'name' => 'users',
+                            'id' => 'users-2',
+                            'value' => 2,
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                            'option 2',
+                        '/label',
+                    '/div',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignRadioControlWithCustomLabelTemplateIsBackwardsCompatible()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('users', [
+            'type' => 'radio',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'templates' => [
+                'radioLabel' =>
+                    '<label id="{{groupId}}" class="col-form-label d-block pt-0 %s" back="compat">{{text}}{{tooltip}}</label>',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group row radio',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['label' => [
+                    'id' => 'users-group-label',
+                    'class' => 'col-form-label d-block pt-0 %s',
+                    'back' => 'compat',
+                ]],
+                    'Users',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    ['input' => [
+                        'type' => 'hidden',
+                        'name' => 'users',
+                        'value' => '',
+                    ]],
+                    ['div' => ['class' => 'form-check']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'radio',
+                            'name' => 'users',
+                            'id' => 'users-1',
+                            'value' => 1,
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                            'option 1',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'form-check']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'radio',
+                            'name' => 'users',
+                            'id' => 'users-2',
+                            'value' => 2,
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                            'option 2',
+                        '/label',
+                    '/div',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testHorizontalAlignRadioControlWithHelp()
     {
         $this->Form->create($this->article, [
@@ -809,6 +944,143 @@ class RadioControlTest extends AbstractFormHelperTest
             ['div' => ['class' => 'form-group row radio', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
                 ['label' => ['id' => 'users-group-label', 'class' => 'col-form-label d-block pt-0 col-sm-5']],
                     'Custom Label',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    ['input' => [
+                        'type' => 'hidden',
+                        'name' => 'users',
+                        'value' => '',
+                    ]],
+                    ['div' => ['class' => 'form-check form-check-inline']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'radio',
+                            'name' => 'users',
+                            'id' => 'users-1',
+                            'value' => 1,
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                            'option 1',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'form-check form-check-inline']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'radio',
+                            'name' => 'users',
+                            'id' => 'users-2',
+                            'value' => 2,
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                            'option 2',
+                        '/label',
+                    '/div',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignRadioControlInlineWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('users', [
+            'type' => 'radio',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'inline' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group row radio', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['label' => ['id' => 'users-group-label', 'class' => 'custom-label-class col-form-label d-block pt-0 col-sm-5', 'foo' => 'bar']],
+                    'Custom Label',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    ['input' => [
+                        'type' => 'hidden',
+                        'name' => 'users',
+                        'value' => '',
+                    ]],
+                    ['div' => ['class' => 'form-check form-check-inline']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'radio',
+                            'name' => 'users',
+                            'id' => 'users-1',
+                            'value' => 1,
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                            'option 1',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'form-check form-check-inline']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'radio',
+                            'name' => 'users',
+                            'id' => 'users-2',
+                            'value' => 2,
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                            'option 2',
+                        '/label',
+                    '/div',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignRadioControlInlineWithCustomLabelTemplateIsBackwardsCompatible()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('users', [
+            'type' => 'radio',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'inline' => true,
+            'templates' => [
+                'radioLabel' =>
+                    '<label id="{{groupId}}" class="col-form-label d-block pt-0 %s" back="compat">{{text}}{{tooltip}}</label>',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group row radio',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['label' => [
+                    'id' => 'users-group-label',
+                    'class' => 'col-form-label d-block pt-0 %s',
+                    'back' => 'compat',
+                ]],
+                    'Users',
                 '/label',
                 ['div' => ['class' => 'col-sm-7']],
                     ['input' => [

--- a/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/RadioCustomControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/RadioCustomControlTest.php
@@ -194,6 +194,147 @@ class RadioCustomControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testHorizontalAlignCustomRadioControlWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('users', [
+            'type' => 'radio',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'custom' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group row radio',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['label' => ['id' => 'users-group-label', 'class' => 'custom-label-class col-form-label d-block pt-0 col-sm-5', 'foo' => 'bar']],
+                    'Custom Label',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    ['input' => [
+                        'type' => 'hidden',
+                        'name' => 'users',
+                        'value' => '',
+                    ]],
+                    ['div' => ['class' => 'custom-control custom-radio']],
+                        ['input' => [
+                            'class' => 'custom-control-input',
+                            'type' => 'radio',
+                            'name' => 'users',
+                            'id' => 'users-1',
+                            'value' => 1,
+                        ]],
+                        ['label' => ['class' => 'custom-control-label', 'for' => 'users-1']],
+                            'option 1',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'custom-control custom-radio']],
+                        ['input' => [
+                            'class' => 'custom-control-input',
+                            'type' => 'radio',
+                            'name' => 'users',
+                            'id' => 'users-2',
+                            'value' => 2,
+                        ]],
+                        ['label' => ['class' => 'custom-control-label', 'for' => 'users-2']],
+                            'option 2',
+                        '/label',
+                    '/div',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignCustomRadioControlWithCustomLabelTemplateIsBackwardsCompatible()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('users', [
+            'type' => 'radio',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'custom' => true,
+            'templates' => [
+                'radioLabel' =>
+                    '<label id="{{groupId}}" class="col-form-label d-block pt-0 %s" back="compat">{{text}}{{tooltip}}</label>',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group row radio',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['label' => [
+                    'id' => 'users-group-label',
+                    'class' => 'col-form-label d-block pt-0 %s',
+                    'back' => 'compat',
+                ]],
+                    'Users',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    ['input' => [
+                        'type' => 'hidden',
+                        'name' => 'users',
+                        'value' => '',
+                    ]],
+                    ['div' => ['class' => 'custom-control custom-radio']],
+                        ['input' => [
+                            'class' => 'custom-control-input',
+                            'type' => 'radio',
+                            'name' => 'users',
+                            'id' => 'users-1',
+                            'value' => 1,
+                        ]],
+                        ['label' => ['class' => 'custom-control-label', 'for' => 'users-1']],
+                            'option 1',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'custom-control custom-radio']],
+                        ['input' => [
+                            'class' => 'custom-control-input',
+                            'type' => 'radio',
+                            'name' => 'users',
+                            'id' => 'users-2',
+                            'value' => 2,
+                        ]],
+                        ['label' => ['class' => 'custom-control-label', 'for' => 'users-2']],
+                            'option 2',
+                        '/label',
+                    '/div',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testHorizontalAlignCustomRadioControlWithHelp()
     {
         $this->Form->create($this->article, [
@@ -714,6 +855,149 @@ class RadioCustomControlTest extends AbstractFormHelperTest
             ]],
                 ['label' => ['id' => 'users-group-label', 'class' => 'col-form-label d-block pt-0 col-sm-5']],
                     'Custom Label',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    ['input' => [
+                        'type' => 'hidden',
+                        'name' => 'users',
+                        'value' => '',
+                    ]],
+                    ['div' => ['class' => 'custom-control custom-radio custom-control-inline']],
+                        ['input' => [
+                            'class' => 'custom-control-input',
+                            'type' => 'radio',
+                            'name' => 'users',
+                            'id' => 'users-1',
+                            'value' => 1,
+                        ]],
+                        ['label' => ['class' => 'custom-control-label', 'for' => 'users-1']],
+                            'option 1',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'custom-control custom-radio custom-control-inline']],
+                        ['input' => [
+                            'class' => 'custom-control-input',
+                            'type' => 'radio',
+                            'name' => 'users',
+                            'id' => 'users-2',
+                            'value' => 2,
+                        ]],
+                        ['label' => ['class' => 'custom-control-label', 'for' => 'users-2']],
+                            'option 2',
+                        '/label',
+                    '/div',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignCustomRadioControlInlineWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('users', [
+            'type' => 'radio',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'custom' => true,
+            'inline' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group row radio',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['label' => ['id' => 'users-group-label', 'class' => 'custom-label-class col-form-label d-block pt-0 col-sm-5', 'foo' => 'bar']],
+                    'Custom Label',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    ['input' => [
+                        'type' => 'hidden',
+                        'name' => 'users',
+                        'value' => '',
+                    ]],
+                    ['div' => ['class' => 'custom-control custom-radio custom-control-inline']],
+                        ['input' => [
+                            'class' => 'custom-control-input',
+                            'type' => 'radio',
+                            'name' => 'users',
+                            'id' => 'users-1',
+                            'value' => 1,
+                        ]],
+                        ['label' => ['class' => 'custom-control-label', 'for' => 'users-1']],
+                            'option 1',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'custom-control custom-radio custom-control-inline']],
+                        ['input' => [
+                            'class' => 'custom-control-input',
+                            'type' => 'radio',
+                            'name' => 'users',
+                            'id' => 'users-2',
+                            'value' => 2,
+                        ]],
+                        ['label' => ['class' => 'custom-control-label', 'for' => 'users-2']],
+                            'option 2',
+                        '/label',
+                    '/div',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignCustomRadioControlInlineWithCustomLabelTemplateIsBackwardsCompatible()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('users', [
+            'type' => 'radio',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'custom' => true,
+            'inline' => true,
+            'templates' => [
+                'radioLabel' =>
+                    '<label id="{{groupId}}" class="col-form-label d-block pt-0 %s" back="compat">{{text}}{{tooltip}}</label>',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group row radio',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['label' => [
+                    'id' => 'users-group-label',
+                    'class' => 'col-form-label d-block pt-0 %s',
+                    'back' => 'compat',
+                ]],
+                    'Users',
                 '/label',
                 ['div' => ['class' => 'col-sm-7']],
                     ['input' => [

--- a/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/RangeControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/RangeControlTest.php
@@ -120,6 +120,49 @@ class RangeControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testHorizontalAlignRangeControlWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('height', [
+            'type' => 'range',
+            'min' => 0,
+            'max' => 10,
+            'step' => 1,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            'div' => ['class' => 'form-group row range'],
+                ['label' => ['class' => 'custom-label-class col-form-label col-sm-5', 'foo' => 'bar', 'for' => 'height']],
+                    'Custom Label',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    'input' => [
+                        'type' => 'range',
+                        'name' => 'height',
+                        'min' => 0,
+                        'max' => 10,
+                        'step' => 1,
+                        'id' => 'height',
+                        'class' => 'form-control',
+                    ],
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testHorizontalAlignRangeControlWithHelp()
     {
         $this->Form->create($this->article, [

--- a/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/RangeCustomControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/RangeCustomControlTest.php
@@ -123,6 +123,50 @@ class RangeCustomControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testHorizontalAlignCustomRangeControlWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('height', [
+            'type' => 'range',
+            'min' => 0,
+            'max' => 10,
+            'step' => 1,
+            'custom' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            'div' => ['class' => 'form-group row range'],
+                ['label' => ['class' => 'custom-label-class col-form-label col-sm-5', 'foo' => 'bar', 'for' => 'height']],
+                    'Custom Label',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    'input' => [
+                        'type' => 'range',
+                        'name' => 'height',
+                        'min' => 0,
+                        'max' => 10,
+                        'step' => 1,
+                        'id' => 'height',
+                        'class' => 'custom-range',
+                    ],
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testHorizontalAlignCustomRangeControlWithHelp()
     {
         $this->Form->create($this->article, [

--- a/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/SelectControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/SelectControlTest.php
@@ -122,8 +122,6 @@ class SelectControlTest extends AbstractFormHelperTest
 
     public function testHorizontalAlignSelectControlWithCustomLabelOptions()
     {
-        $this->markTestSkipped('Custom label options currently do not work');
-
         $this->Form->create($this->article, [
             'align' => [
                 'sm' => [

--- a/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/SelectCustomControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/SelectCustomControlTest.php
@@ -123,6 +123,50 @@ class SelectCustomControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testHorizontalAlignCustomSelectControlWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    'left' => 5,
+                    'middle' => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('users', [
+            'type' => 'select',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'custom' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group row select']],
+                ['label' => ['class' => 'custom-label-class col-form-label col-sm-5', 'foo' => 'bar', 'for' => 'users']],
+                    'Custom Label',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    ['select' => ['name' => 'users', 'id' => 'users', 'class' => 'custom-select']],
+                        ['option' => ['value' => '1']],
+                            'option 1',
+                        '/option',
+                        ['option' => ['value' => '2']],
+                            'option 2',
+                        '/option',
+                    '/select',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testHorizontalAlignCustomSelectControlWithHelp()
     {
         $this->Form->create($this->article, [

--- a/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/StaticControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/StaticControlTest.php
@@ -160,8 +160,6 @@ class StaticControlTest extends AbstractFormHelperTest
 
     public function testHorizontalAlignStaticControlWithCustomLabelOptions()
     {
-        $this->markTestSkipped('Custom label options currently do not work');
-
         unset($this->article['required']['title']);
         $this->article['defaults']['title'] = 'title';
         $this->Form->create($this->article, [

--- a/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/TextControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/TextControlTest.php
@@ -99,8 +99,6 @@ class TextControlTest extends AbstractFormHelperTest
 
     public function testHorizontalAlignTextControlWithCustomLabelOptions()
     {
-        $this->markTestSkipped('Custom label options currently do not work');
-
         unset($this->article['required']['title']);
         $this->Form->create($this->article, [
             'align' => [

--- a/tests/TestCase/View/Helper/FormHelper/InlineAlign/CheckboxControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/InlineAlign/CheckboxControlTest.php
@@ -105,6 +105,44 @@ class CheckboxControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testInlineAlignCheckboxControlWithCustomLabelOptions()
+    {
+        $this->withErrorReporting(0, function () {
+            $this->Form->create($this->article, [
+                'align' => 'inline',
+            ]);
+        });
+
+        $result = $this->Form->control('users', [
+            'type' => 'checkbox',
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-check form-check-inline checkbox']],
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => 0,
+                ]],
+                ['input' => [
+                    'class' => 'form-check-input',
+                    'type' => 'checkbox',
+                    'name' => 'users',
+                    'id' => 'users',
+                    'value' => 1,
+                ]],
+                ['label' => ['class' => 'custom-label-class form-check-label', 'foo' => 'bar', 'for' => 'users']],
+                    'Custom Label',
+                '/label',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testInlineAlignCheckboxControlWithHelp()
     {
         $this->withErrorReporting(0, function () {

--- a/tests/TestCase/View/Helper/FormHelper/InlineAlign/CheckboxCustomControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/InlineAlign/CheckboxCustomControlTest.php
@@ -108,6 +108,45 @@ class CheckboxCustomControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testInlineAlignCustomCheckboxControlWithCustomLabelOptions()
+    {
+        $this->withErrorReporting(0, function () {
+            $this->Form->create($this->article, [
+                'align' => 'inline',
+            ]);
+        });
+
+        $result = $this->Form->control('users', [
+            'type' => 'checkbox',
+            'custom' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group custom-control custom-checkbox custom-control-inline checkbox']],
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => 0,
+                ]],
+                ['input' => [
+                    'type' => 'checkbox',
+                    'name' => 'users',
+                    'value' => '1',
+                    'id' => 'users',
+                    'class' => 'custom-control-input',
+                ]],
+                ['label' => ['class' => 'custom-label-class custom-control-label', 'foo' => 'bar', 'for' => 'users']],
+                    'Custom Label',
+                '/label',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testInlineAlignCustomCheckboxControlWithHelp()
     {
         $this->withErrorReporting(0, function () {

--- a/tests/TestCase/View/Helper/FormHelper/InlineAlign/DateTimeControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/InlineAlign/DateTimeControlTest.php
@@ -22,10 +22,10 @@ class DateTimeControlTest extends AbstractFormHelperTest
             'value' => $now->format('Y-m-d H:i:s'),
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group position-relative datetime-local', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only', 'for' => 'created']],
+            ['div' => ['class' => 'form-group position-relative datetime-local']],
+                ['label' => ['class' => 'sr-only', 'for' => 'created']],
                     'Created',
-                '/span',
+                '/label',
                 'input' => [
                     'type' => 'datetime-local',
                     'name' => 'created',
@@ -54,7 +54,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
             'label' => false,
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group position-relative datetime-local', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
+            ['div' => ['class' => 'form-group position-relative datetime-local']],
                 'input' => [
                     'type' => 'datetime-local',
                     'name' => 'created',
@@ -83,10 +83,10 @@ class DateTimeControlTest extends AbstractFormHelperTest
             'label' => 'Custom Label',
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group position-relative datetime-local', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only', 'for' => 'created']],
+            ['div' => ['class' => 'form-group position-relative datetime-local']],
+                ['label' => ['class' => 'sr-only', 'for' => 'created']],
                     'Custom Label',
-                '/span',
+                '/label',
                 'input' => [
                     'type' => 'datetime-local',
                     'name' => 'created',
@@ -119,10 +119,10 @@ class DateTimeControlTest extends AbstractFormHelperTest
             ],
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group position-relative datetime-local', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['span' => ['id' => 'created-group-label', 'class' => 'custom-label-class sr-only', 'foo' => 'bar', 'for' => 'created']],
+            ['div' => ['class' => 'form-group position-relative datetime-local']],
+                ['label' => ['class' => 'custom-label-class sr-only', 'foo' => 'bar', 'for' => 'created']],
                     'Custom Label',
-                '/span',
+                '/label',
                 'input' => [
                     'type' => 'datetime-local',
                     'name' => 'created',
@@ -149,6 +149,10 @@ class DateTimeControlTest extends AbstractFormHelperTest
             'type' => 'datetime-local',
             'value' => $now->format('Y-m-d H:i:s'),
             'templates' => [
+                'datetimeContainer' =>
+                    '<div{{containerAttrs}} ' .
+                        'class="{{containerClass}}form-group {{formGroupPosition}}{{type}}{{required}}" ' .
+                            'role="group" aria-labelledby="{{groupId}}">{{content}}{{help}}</div>',
                 'datetimeLabel' => '<span id="{{groupId}}" class="sr-only" back="compat">{{text}}{{tooltip}}</span>',
             ],
         ]);
@@ -193,10 +197,10 @@ class DateTimeControlTest extends AbstractFormHelperTest
             'help' => 'Help text',
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group position-relative datetime-local', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only', 'for' => 'created']],
+            ['div' => ['class' => 'form-group position-relative datetime-local']],
+                ['label' => ['class' => 'sr-only', 'for' => 'created']],
                     'Created',
-                '/span',
+                '/label',
                 'input' => [
                     'type' => 'datetime-local',
                     'name' => 'created',
@@ -231,10 +235,10 @@ class DateTimeControlTest extends AbstractFormHelperTest
             ],
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group position-relative datetime-local', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only', 'for' => 'created']],
+            ['div' => ['class' => 'form-group position-relative datetime-local']],
+                ['label' => ['class' => 'sr-only', 'for' => 'created']],
                     'Created',
-                '/span',
+                '/label',
                 'input' => [
                     'type' => 'datetime-local',
                     'name' => 'created',
@@ -266,8 +270,8 @@ class DateTimeControlTest extends AbstractFormHelperTest
             'tooltip' => 'Tooltip text',
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group position-relative datetime-local', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only', 'for' => 'created']],
+            ['div' => ['class' => 'form-group position-relative datetime-local']],
+                ['label' => ['class' => 'sr-only', 'for' => 'created']],
                     'Created ',
                     'span' => [
                         'data-toggle' => 'tooltip',
@@ -275,7 +279,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
                         'class' => 'fas fa-info-circle',
                     ],
                     '/span',
-                '/span',
+                '/label',
                 'input' => [
                     'type' => 'datetime-local',
                     'name' => 'created',
@@ -311,12 +315,10 @@ class DateTimeControlTest extends AbstractFormHelperTest
         $expected = [
             ['div' => [
                 'class' => 'form-group position-relative datetime-local is-invalid',
-                'role' => 'group',
-                'aria-labelledby' => 'created-group-label',
             ]],
-                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only', 'for' => 'created']],
+                ['label' => ['class' => 'sr-only', 'for' => 'created']],
                     'Created',
-                '/span',
+                '/label',
                 'input' => [
                     'type' => 'datetime-local',
                     'name' => 'created',
@@ -354,12 +356,10 @@ class DateTimeControlTest extends AbstractFormHelperTest
             ['div' => [
                 'attribute' => 'container-attribute',
                 'class' => 'container-class form-group position-relative datetime-local',
-                'role' => 'group',
-                'aria-labelledby' => 'created-group-label',
             ]],
-                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only', 'for' => 'created']],
+                ['label' => ['class' => 'sr-only', 'for' => 'created']],
                     'Created',
-                '/span',
+                '/label',
                 'input' => [
                     'type' => 'datetime-local',
                     'name' => 'created',
@@ -400,12 +400,10 @@ class DateTimeControlTest extends AbstractFormHelperTest
             ['div' => [
                 'attribute' => 'container-attribute',
                 'class' => 'container-class form-group position-relative datetime-local is-invalid',
-                'role' => 'group',
-                'aria-labelledby' => 'created-group-label',
             ]],
-                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only', 'for' => 'created']],
+                ['label' => ['class' => 'sr-only', 'for' => 'created']],
                     'Created',
-                '/span',
+                '/label',
                 'input' => [
                     'type' => 'datetime-local',
                     'name' => 'created',
@@ -436,10 +434,10 @@ class DateTimeControlTest extends AbstractFormHelperTest
             'value' => $now,
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group position-relative date', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only', 'for' => 'created']],
+            ['div' => ['class' => 'form-group position-relative date']],
+                ['label' => ['class' => 'sr-only', 'for' => 'created']],
                     'Created',
-                '/span',
+                '/label',
                 'input' => [
                     'type' => 'date',
                     'name' => 'created',
@@ -467,10 +465,10 @@ class DateTimeControlTest extends AbstractFormHelperTest
             'value' => $now,
         ]);
         $expected = [
-            ['div' => ['class' => 'form-group position-relative time', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only', 'for' => 'created']],
+            ['div' => ['class' => 'form-group position-relative time']],
+                ['label' => ['class' => 'sr-only', 'for' => 'created']],
                     'Created',
-                '/span',
+                '/label',
                 'input' => [
                     'type' => 'time',
                     'name' => 'created',
@@ -495,17 +493,17 @@ class DateTimeControlTest extends AbstractFormHelperTest
         $result = $this->Form->control('created', [
             'type' => 'datetime',
         ]);
-        $this->assertStringContainsString('<div class="form-group position-relative datetime" role="group" aria-labelledby="created-group-label">', $result);
+        $this->assertStringContainsString('<div class="form-group position-relative datetime">', $result);
 
         $result = $this->Form->control('created', [
             'type' => 'date',
         ]);
-        $this->assertStringContainsString('<div class="form-group position-relative date" role="group" aria-labelledby="created-group-label">', $result);
+        $this->assertStringContainsString('<div class="form-group position-relative date">', $result);
 
         $result = $this->Form->control('created', [
             'type' => 'time',
         ]);
-        $this->assertStringContainsString('<div class="form-group position-relative time" role="group" aria-labelledby="created-group-label">', $result);
+        $this->assertStringContainsString('<div class="form-group position-relative time">', $result);
 
         $this->Form->setTemplates([
             'datetimeContainer' => '<div class="custom datetimeContainer {{type}}{{required}}" role="group" aria-labelledby="{{groupId}}">{{content}}</div>',
@@ -544,17 +542,17 @@ class DateTimeControlTest extends AbstractFormHelperTest
         $result = $this->Form->control('created', [
             'type' => 'datetime',
         ]);
-        $this->assertStringContainsString('<div class="form-group position-relative datetime is-invalid" role="group" aria-labelledby="created-group-label">', $result);
+        $this->assertStringContainsString('<div class="form-group position-relative datetime is-invalid">', $result);
 
         $result = $this->Form->control('created', [
             'type' => 'date',
         ]);
-        $this->assertStringContainsString('<div class="form-group position-relative date is-invalid" role="group" aria-labelledby="created-group-label">', $result);
+        $this->assertStringContainsString('<div class="form-group position-relative date is-invalid">', $result);
 
         $result = $this->Form->control('created', [
             'type' => 'time',
         ]);
-        $this->assertStringContainsString('<div class="form-group position-relative time is-invalid" role="group" aria-labelledby="created-group-label">', $result);
+        $this->assertStringContainsString('<div class="form-group position-relative time is-invalid">', $result);
 
         $result = $this->Form->control('created', [
             'type' => 'datetime',

--- a/tests/TestCase/View/Helper/FormHelper/InlineAlign/DateTimeControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/InlineAlign/DateTimeControlTest.php
@@ -23,7 +23,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
         ]);
         $expected = [
             ['div' => ['class' => 'form-group position-relative datetime-local', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only']],
+                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only', 'for' => 'created']],
                     'Created',
                 '/span',
                 'input' => [
@@ -84,8 +84,86 @@ class DateTimeControlTest extends AbstractFormHelperTest
         ]);
         $expected = [
             ['div' => ['class' => 'form-group position-relative datetime-local', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only']],
+                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only', 'for' => 'created']],
                     'Custom Label',
+                '/span',
+                'input' => [
+                    'type' => 'datetime-local',
+                    'name' => 'created',
+                    'id' => 'created',
+                    'class' => 'form-control',
+                    'value' => $now->format('Y-m-d H:i:s'),
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testInlineAlignDateTimeControlWithCustomLabelOptions()
+    {
+        $this->withErrorReporting(0, function () {
+            $this->Form->create($this->article, [
+                'align' => 'inline',
+            ]);
+        });
+
+        $now = new \DateTime('now');
+
+        $result = $this->Form->control('created', [
+            'type' => 'datetime-local',
+            'value' => $now->format('Y-m-d H:i:s'),
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group position-relative datetime-local', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
+                ['span' => ['id' => 'created-group-label', 'class' => 'custom-label-class sr-only', 'foo' => 'bar', 'for' => 'created']],
+                    'Custom Label',
+                '/span',
+                'input' => [
+                    'type' => 'datetime-local',
+                    'name' => 'created',
+                    'id' => 'created',
+                    'class' => 'form-control',
+                    'value' => $now->format('Y-m-d H:i:s'),
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testInlineAlignDateTimeControlWithCustomLabelTemplateIsBackwardsCompatible()
+    {
+        $this->withErrorReporting(0, function () {
+            $this->Form->create($this->article, [
+                'align' => 'inline',
+            ]);
+        });
+
+        $now = new \DateTime('now');
+
+        $result = $this->Form->control('created', [
+            'type' => 'datetime-local',
+            'value' => $now->format('Y-m-d H:i:s'),
+            'templates' => [
+                'datetimeLabel' => '<span id="{{groupId}}" class="sr-only" back="compat">{{text}}{{tooltip}}</span>',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group position-relative datetime-local',
+                'role' => 'group',
+                'aria-labelledby' => 'created-group-label',
+            ]],
+                ['span' => [
+                    'id' => 'created-group-label',
+                    'class' => 'sr-only',
+                    'back' => 'compat',
+                ]],
+                    'Created',
                 '/span',
                 'input' => [
                     'type' => 'datetime-local',
@@ -116,7 +194,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
         ]);
         $expected = [
             ['div' => ['class' => 'form-group position-relative datetime-local', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only']],
+                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only', 'for' => 'created']],
                     'Created',
                 '/span',
                 'input' => [
@@ -154,7 +232,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
         ]);
         $expected = [
             ['div' => ['class' => 'form-group position-relative datetime-local', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only']],
+                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only', 'for' => 'created']],
                     'Created',
                 '/span',
                 'input' => [
@@ -189,7 +267,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
         ]);
         $expected = [
             ['div' => ['class' => 'form-group position-relative datetime-local', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only']],
+                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only', 'for' => 'created']],
                     'Created ',
                     'span' => [
                         'data-toggle' => 'tooltip',
@@ -236,7 +314,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
                 'role' => 'group',
                 'aria-labelledby' => 'created-group-label',
             ]],
-                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only']],
+                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only', 'for' => 'created']],
                     'Created',
                 '/span',
                 'input' => [
@@ -279,7 +357,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
                 'role' => 'group',
                 'aria-labelledby' => 'created-group-label',
             ]],
-                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only']],
+                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only', 'for' => 'created']],
                     'Created',
                 '/span',
                 'input' => [
@@ -325,7 +403,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
                 'role' => 'group',
                 'aria-labelledby' => 'created-group-label',
             ]],
-                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only']],
+                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only', 'for' => 'created']],
                     'Created',
                 '/span',
                 'input' => [
@@ -359,7 +437,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
         ]);
         $expected = [
             ['div' => ['class' => 'form-group position-relative date', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only']],
+                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only', 'for' => 'created']],
                     'Created',
                 '/span',
                 'input' => [
@@ -390,7 +468,7 @@ class DateTimeControlTest extends AbstractFormHelperTest
         ]);
         $expected = [
             ['div' => ['class' => 'form-group position-relative time', 'role' => 'group', 'aria-labelledby' => 'created-group-label']],
-                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only']],
+                ['span' => ['id' => 'created-group-label', 'class' => 'sr-only', 'for' => 'created']],
                     'Created',
                 '/span',
                 'input' => [

--- a/tests/TestCase/View/Helper/FormHelper/InlineAlign/FileControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/InlineAlign/FileControlTest.php
@@ -87,6 +87,38 @@ class FileControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testInlineAlignFileControlWithCustomLabelOptions()
+    {
+        $this->withErrorReporting(0, function () {
+            $this->Form->create($this->article, [
+                'align' => 'inline',
+            ]);
+        });
+
+        $result = $this->Form->control('file', [
+            'type' => 'file',
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group file']],
+                ['label' => ['class' => 'custom-label-class sr-only', 'foo' => 'bar', 'for' => 'file']],
+                    'Custom Label',
+                '/label',
+                ['input' => [
+                    'type' => 'file',
+                    'name' => 'file',
+                    'id' => 'file',
+                    'class' => 'form-control-file',
+                ]],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testInlineAlignFileControlWithHelp()
     {
         $this->withErrorReporting(0, function () {

--- a/tests/TestCase/View/Helper/FormHelper/InlineAlign/FileCustomControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/InlineAlign/FileCustomControlTest.php
@@ -96,6 +96,81 @@ class FileCustomControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testInlineAlignCustomFileControlWithCustomLabelOptions()
+    {
+        $this->withErrorReporting(0, function () {
+            $this->Form->create($this->article, [
+                'align' => 'inline',
+            ]);
+        });
+
+        $result = $this->Form->control('file', [
+            'type' => 'file',
+            'custom' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group file']],
+                ['div' => ['class' => 'custom-file ']],
+                    ['input' => [
+                        'type' => 'file',
+                        'name' => 'file',
+                        'id' => 'file',
+                        'class' => 'custom-file-input',
+                    ]],
+                    ['label' => ['class' => 'custom-label-class custom-file-label', 'foo' => 'bar', 'for' => 'file']],
+                        'Custom Label',
+                    '/label',
+                 '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * Inline custom file control label templates are not backwards compatible,
+     * they will produce a duplicate `class` attribute.
+     */
+    public function testInlineAlignCustomFileControlWithCustomLabelTemplateIsBackwardsCompatible()
+    {
+        $this->markTestIncomplete('Inline custom file control label templates are not backwards compatible');
+
+        $this->withErrorReporting(0, function () {
+            $this->Form->create($this->article, [
+                'align' => 'inline',
+            ]);
+        });
+
+        $result = $this->Form->control('file', [
+            'type' => 'file',
+            'custom' => true,
+            'templates' => [
+                'customFileLabel' =>
+                    '<label class="custom-file-label"{{attrs}} back="compat">{{text}}{{tooltip}}</label>',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group file']],
+                ['div' => ['class' => 'custom-file ']],
+                    ['input' => [
+                        'type' => 'file',
+                        'name' => 'file',
+                        'id' => 'file',
+                        'class' => 'custom-file-input',
+                    ]],
+                    ['label' => ['class' => 'custom-file-label', 'for' => 'file', 'back' => 'compact']],
+                        'File',
+                    '/label',
+                 '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testInlineAlignCustomFileControlWithHelp()
     {
         $this->withErrorReporting(0, function () {

--- a/tests/TestCase/View/Helper/FormHelper/InlineAlign/MultipleCheckboxControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/InlineAlign/MultipleCheckboxControlTest.php
@@ -176,6 +176,131 @@ class MultipleCheckboxControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testInlineAlignMultipleCheckboxControlWithCustomLabelOptions()
+    {
+        $this->withErrorReporting(0, function () {
+            $this->Form->create($this->article, [
+                'align' => 'inline',
+            ]);
+        });
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group position-relative multicheckbox',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['span' => ['id' => 'users-group-label', 'class' => 'custom-label-class sr-only', 'foo' => 'bar']],
+                    'Custom Label',
+                '/span',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-1',
+                        'value' => 1,
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-2',
+                        'value' => 2,
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testInlineAlignMultipleCheckboxControlWithCustomLabelTemplateIsBackwardsCompatible()
+    {
+        $this->withErrorReporting(0, function () {
+            $this->Form->create($this->article, [
+                'align' => 'inline',
+            ]);
+        });
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'templates' => [
+                'multicheckboxLabel' =>
+                    '<span id="{{groupId}}" class="sr-only" back="compat">{{text}}{{tooltip}}</span>',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group position-relative multicheckbox',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['span' => ['id' => 'users-group-label', 'class' => 'sr-only', 'back' => 'compat']],
+                    'Users',
+                '/span',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-1',
+                        'value' => 1,
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-2',
+                        'value' => 2,
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testInlineAlignMultipleCheckboxControlWithHelp()
     {
         $this->withErrorReporting(0, function () {

--- a/tests/TestCase/View/Helper/FormHelper/InlineAlign/MultipleCheckboxCustomControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/InlineAlign/MultipleCheckboxCustomControlTest.php
@@ -179,6 +179,133 @@ class MultipleCheckboxCustomControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testInlineAlignCustomMultipleCheckboxControlWithCustomLabelOptions()
+    {
+        $this->withErrorReporting(0, function () {
+            $this->Form->create($this->article, [
+                'align' => 'inline',
+            ]);
+        });
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'custom' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group position-relative multicheckbox',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['span' => ['id' => 'users-group-label', 'class' => 'custom-label-class sr-only', 'foo' => 'bar']],
+                    'Custom Label',
+                '/span',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'custom-control custom-checkbox custom-control-inline']],
+                    ['input' => [
+                        'class' => 'custom-control-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-1',
+                        'value' => 1,
+                    ]],
+                    ['label' => ['class' => 'custom-control-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'custom-control custom-checkbox custom-control-inline']],
+                    ['input' => [
+                        'class' => 'custom-control-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-2',
+                        'value' => 2,
+                    ]],
+                    ['label' => ['class' => 'custom-control-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testInlineAlignCustomMultipleCheckboxControlWithCustomLabelTemplateIsBackwardsCompatible()
+    {
+        $this->withErrorReporting(0, function () {
+            $this->Form->create($this->article, [
+                'align' => 'inline',
+            ]);
+        });
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'custom' => true,
+            'templates' => [
+                'multicheckboxLabel' =>
+                    '<span id="{{groupId}}" class="sr-only" back="compat">{{text}}{{tooltip}}</span>',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group position-relative multicheckbox',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['span' => ['id' => 'users-group-label', 'class' => 'sr-only', 'back' => 'compat']],
+                    'Users',
+                '/span',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'custom-control custom-checkbox custom-control-inline']],
+                    ['input' => [
+                        'class' => 'custom-control-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-1',
+                        'value' => 1,
+                    ]],
+                    ['label' => ['class' => 'custom-control-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'custom-control custom-checkbox custom-control-inline']],
+                    ['input' => [
+                        'class' => 'custom-control-input',
+                        'type' => 'checkbox',
+                        'name' => 'users[]',
+                        'id' => 'users-2',
+                        'value' => 2,
+                    ]],
+                    ['label' => ['class' => 'custom-control-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testInlineAlignCustomMultipleCheckboxControlWithHelp()
     {
         $this->withErrorReporting(0, function () {

--- a/tests/TestCase/View/Helper/FormHelper/InlineAlign/RadioControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/InlineAlign/RadioControlTest.php
@@ -168,6 +168,127 @@ class RadioControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testInlineAlignRadioControlWithCustomLabelOptions()
+    {
+        $this->withErrorReporting(0, function () {
+            $this->Form->create($this->article, [
+                'align' => 'inline',
+            ]);
+        });
+
+        $result = $this->Form->control('users', [
+            'type' => 'radio',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group position-relative radio', 'role' => 'group', 'aria-labelledby' => 'users-group-label']],
+                ['span' => ['id' => 'users-group-label', 'class' => 'custom-label-class sr-only', 'foo' => 'bar']],
+                    'Custom Label',
+                '/span',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'radio',
+                        'name' => 'users',
+                        'id' => 'users-1',
+                        'value' => 1,
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'radio',
+                        'name' => 'users',
+                        'id' => 'users-2',
+                        'value' => 2,
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testInlineAlignRadioControlWithCustomLabelTemplateIsBackwardsCompatible()
+    {
+        $this->withErrorReporting(0, function () {
+            $this->Form->create($this->article, [
+                'align' => 'inline',
+            ]);
+        });
+
+        $result = $this->Form->control('users', [
+            'type' => 'radio',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'templates' => [
+                'radioLabel' =>
+                    '<span id="{{groupId}}" class="sr-only" back="compat">{{text}}{{tooltip}}</span>',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group position-relative radio',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['span' => ['id' => 'users-group-label', 'class' => 'sr-only', 'back' => 'compat']],
+                    'Users',
+                '/span',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'radio',
+                        'name' => 'users',
+                        'id' => 'users-1',
+                        'value' => 1,
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'form-check form-check-inline']],
+                    ['input' => [
+                        'class' => 'form-check-input',
+                        'type' => 'radio',
+                        'name' => 'users',
+                        'id' => 'users-2',
+                        'value' => 2,
+                    ]],
+                    ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testInlineAlignRadioControlWithHelp()
     {
         $this->withErrorReporting(0, function () {

--- a/tests/TestCase/View/Helper/FormHelper/InlineAlign/RadioCustomControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/InlineAlign/RadioCustomControlTest.php
@@ -173,6 +173,129 @@ class RadioCustomControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testInlineAlignCustomRadioControlWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article, [
+            'align' => 'inline',
+        ]);
+
+        $result = $this->Form->control('users', [
+            'type' => 'radio',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'custom' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group position-relative radio',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['span' => ['id' => 'users-group-label', 'class' => 'custom-label-class sr-only', 'foo' => 'bar']],
+                    'Custom Label',
+                '/span',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'custom-control custom-radio custom-control-inline']],
+                    ['input' => [
+                        'class' => 'custom-control-input',
+                        'type' => 'radio',
+                        'name' => 'users',
+                        'id' => 'users-1',
+                        'value' => 1,
+                    ]],
+                    ['label' => ['class' => 'custom-control-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'custom-control custom-radio custom-control-inline']],
+                    ['input' => [
+                        'class' => 'custom-control-input',
+                        'type' => 'radio',
+                        'name' => 'users',
+                        'id' => 'users-2',
+                        'value' => 2,
+                    ]],
+                    ['label' => ['class' => 'custom-control-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testInlineAlignCustomRadioControlWithCustomLabelTemplateIsBackwardsCompatible()
+    {
+        $this->Form->create($this->article, [
+            'align' => 'inline',
+        ]);
+
+        $result = $this->Form->control('users', [
+            'type' => 'radio',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'custom' => true,
+            'templates' => [
+                'radioLabel' =>
+                    '<span id="{{groupId}}" class="sr-only" back="compat">{{text}}{{tooltip}}</span>',
+            ],
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'form-group position-relative radio',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['span' => ['id' => 'users-group-label', 'class' => 'sr-only', 'back' => 'compat']],
+                    'Users',
+                '/span',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['div' => ['class' => 'custom-control custom-radio custom-control-inline']],
+                    ['input' => [
+                        'class' => 'custom-control-input',
+                        'type' => 'radio',
+                        'name' => 'users',
+                        'id' => 'users-1',
+                        'value' => 1,
+                    ]],
+                    ['label' => ['class' => 'custom-control-label', 'for' => 'users-1']],
+                        'option 1',
+                    '/label',
+                '/div',
+                ['div' => ['class' => 'custom-control custom-radio custom-control-inline']],
+                    ['input' => [
+                        'class' => 'custom-control-input',
+                        'type' => 'radio',
+                        'name' => 'users',
+                        'id' => 'users-2',
+                        'value' => 2,
+                    ]],
+                    ['label' => ['class' => 'custom-control-label', 'for' => 'users-2']],
+                        'option 2',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testInlineAlignCustomRadioControlWithHelp()
     {
         $this->Form->create($this->article, [

--- a/tests/TestCase/View/Helper/FormHelper/InlineAlign/RangeControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/InlineAlign/RangeControlTest.php
@@ -99,6 +99,42 @@ class RangeControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testInlineAlignRangeControlWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article, [
+            'align' => 'inline',
+        ]);
+
+        $result = $this->Form->control('height', [
+            'type' => 'range',
+            'min' => 0,
+            'max' => 10,
+            'step' => 1,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            'div' => ['class' => 'form-group range'],
+                ['label' => ['class' => 'custom-label-class sr-only', 'foo' => 'bar', 'for' => 'height']],
+                    'Custom Label',
+                '/label',
+                'input' => [
+                    'type' => 'range',
+                    'name' => 'height',
+                    'min' => 0,
+                    'max' => 10,
+                    'step' => 1,
+                    'id' => 'height',
+                    'class' => 'form-control',
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testInlineAlignRangeControlWithHelp()
     {
         $this->Form->create($this->article, [

--- a/tests/TestCase/View/Helper/FormHelper/InlineAlign/RangeCustomControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/InlineAlign/RangeCustomControlTest.php
@@ -102,6 +102,43 @@ class RangeCustomControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testInlineAlignCustomRangeControlWithCustomLabelOptions()
+    {
+        $this->Form->create($this->article, [
+            'align' => 'inline',
+        ]);
+
+        $result = $this->Form->control('height', [
+            'type' => 'range',
+            'min' => 0,
+            'max' => 10,
+            'step' => 1,
+            'custom' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            'div' => ['class' => 'form-group range'],
+                ['label' => ['class' => 'custom-label-class sr-only', 'foo' => 'bar', 'for' => 'height']],
+                    'Custom Label',
+                '/label',
+                'input' => [
+                    'type' => 'range',
+                    'name' => 'height',
+                    'min' => 0,
+                    'max' => 10,
+                    'step' => 1,
+                    'id' => 'height',
+                    'class' => 'custom-range',
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testInlineAlignCustomRangeControlWithHelp()
     {
         $this->Form->create($this->article, [

--- a/tests/TestCase/View/Helper/FormHelper/InlineAlign/SelectControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/InlineAlign/SelectControlTest.php
@@ -101,8 +101,6 @@ class SelectControlTest extends AbstractFormHelperTest
 
     public function testInlineAlignSelectControlWithCustomLabelOptions()
     {
-        $this->markTestSkipped('Custom label options currently do not work');
-
         $this->Form->create($this->article, [
             'align' => 'inline',
         ]);

--- a/tests/TestCase/View/Helper/FormHelper/InlineAlign/SelectCustomControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/InlineAlign/SelectCustomControlTest.php
@@ -108,6 +108,45 @@ class SelectCustomControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testInlineAlignCustomSelectControlWithCustomLabelOptions()
+    {
+        $this->withErrorReporting(0, function () {
+            $this->Form->create($this->article, [
+                'align' => 'inline',
+            ]);
+        });
+
+        $result = $this->Form->control('users', [
+            'type' => 'select',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'custom' => true,
+            'label' => [
+                'class' => 'custom-label-class',
+                'foo' => 'bar',
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group select']],
+                ['label' => ['class' => 'custom-label-class sr-only', 'foo' => 'bar', 'for' => 'users']],
+                    'Custom Label',
+                '/label',
+                ['select' => ['name' => 'users', 'id' => 'users', 'class' => 'custom-select']],
+                    ['option' => ['value' => '1']],
+                        'option 1',
+                    '/option',
+                    ['option' => ['value' => '2']],
+                        'option 2',
+                    '/option',
+                '/select',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testInlineAlignCustomSelectControlWithHelp()
     {
         $this->Form->create($this->article, [

--- a/tests/TestCase/View/Helper/FormHelper/InlineAlign/StaticControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/InlineAlign/StaticControlTest.php
@@ -132,8 +132,6 @@ class StaticControlTest extends AbstractFormHelperTest
 
     public function testInlineAlignStaticControlWithCustomLabelOptions()
     {
-        $this->markTestSkipped('Custom label options currently do not work');
-
         unset($this->article['required']['title']);
         $this->article['defaults']['title'] = 'title';
         $this->Form->create($this->article, [

--- a/tests/TestCase/View/Helper/FormHelper/InlineAlign/TextControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/InlineAlign/TextControlTest.php
@@ -78,8 +78,6 @@ class TextControlTest extends AbstractFormHelperTest
 
     public function testInlineAlignTextControlWithCustomLabelOptions()
     {
-        $this->markTestSkipped('Custom label options currently do not work');
-
         unset($this->article['required']['title']);
         $this->Form->create($this->article, [
             'align' => 'inline',


### PR DESCRIPTION
I completely forgot about this one, it was sitting on my system for quite a while now 😔 

I tried two different variants, this one, which attempts to fix the problem via (existing) template attributes, and another one that used additional template variables. The latter, while not requiring that much additional logic in the options handlers, turned into a steaming hot mess, with lots of backwards incompatibility, and problems like empty `class` attributes, so while it might not seem so, this is actually the more reasonable approach, even though it also has a small BC problem with custom file control label templates (specifically duplicate `class` attributes).

As a side effect, this change also fixes the problem of `for` attributes missing on labels for date/time controls. Related to that the ARIA group handling stuff is no longer needed and has been removed, as date/time controls do not consist of multiple inputs anymore, and therefore the `for` attribute will work fine. Generating the group ID template variable for date/time controls however is being kept, that way this change should be backwards compatible with custom templates.

fixes #341