### PR TITLE
Add support for configurable spacing.

### DIFF
--- a/tests/TestCase/View/Helper/FormHelper/DefaultAlign/CheckboxControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/DefaultAlign/CheckboxControlTest.php
@@ -244,6 +244,36 @@ class CheckboxControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testDefaultAlignCheckboxControlWithCustomSpacing()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'type' => 'checkbox',
+            'spacing' => 'custom-spacing',
+        ]);
+        $expected = [
+            ['div' => ['class' => 'custom-spacing form-group form-check checkbox']],
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => 0,
+                ]],
+                ['input' => [
+                    'class' => 'form-check-input',
+                    'type' => 'checkbox',
+                    'name' => 'users',
+                    'id' => 'users',
+                    'value' => 1,
+                ]],
+                ['label' => ['class' => 'form-check-label', 'for' => 'users']],
+                    'Users',
+                '/label',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testDefaultAlignCheckboxControlWithError()
     {
         $this->article['errors'] = [

--- a/tests/TestCase/View/Helper/FormHelper/DefaultAlign/ColorControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/DefaultAlign/ColorControlTest.php
@@ -212,6 +212,32 @@ class ColorControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testDefaultAlignColorControlWithCustomSpacing()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('color', [
+            'type' => 'color',
+            'value' => '#ffffff',
+            'spacing' => 'custom-spacing',
+        ]);
+        $expected = [
+            'div' => ['class' => 'custom-spacing form-group color'],
+                ['label' => ['class' => 'form-label', 'for' => 'color']],
+                    'Color',
+                '/label',
+                'input' => [
+                    'type' => 'color',
+                    'name' => 'color',
+                    'id' => 'color',
+                    'class' => 'form-control form-control-color',
+                    'value' => '#ffffff',
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testDefaultAlignColorControlWithError()
     {
         $this->article['errors'] = [

--- a/tests/TestCase/View/Helper/FormHelper/DefaultAlign/DateTimeControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/DefaultAlign/DateTimeControlTest.php
@@ -243,6 +243,35 @@ class DateTimeControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testDefaultAlignDateTimeControlWithCustomSpacing()
+    {
+        $this->Form->create($this->article);
+
+        $now = new \DateTime('now');
+
+        $result = $this->Form->control('created', [
+            'type' => 'datetime-local',
+            'value' => $now->format('Y-m-d H:i:s'),
+            'spacing' => 'custom-spacing',
+        ]);
+
+        $expected = [
+            ['div' => ['class' => 'custom-spacing form-group datetime-local']],
+            ['label' => ['class' => 'form-label', 'for' => 'created']],
+            'Created',
+            '/label',
+            'input' => [
+                'type' => 'datetime-local',
+                'name' => 'created',
+                'id' => 'created',
+                'class' => 'form-control',
+                'value' => $now->format('Y-m-d H:i:s'),
+            ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testDefaultAlignDateTimeControlWithError()
     {
         $this->article['errors'] = [

--- a/tests/TestCase/View/Helper/FormHelper/DefaultAlign/FileControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/DefaultAlign/FileControlTest.php
@@ -202,6 +202,30 @@ class FileControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testDefaultAlignFileControlWithCustomSpacing()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('file', [
+            'type' => 'file',
+            'spacing' => 'custom-spacing',
+        ]);
+        $expected = [
+            ['div' => ['class' => 'custom-spacing form-group file']],
+                ['label' => ['class' => 'form-label', 'for' => 'file']],
+                    'File',
+                '/label',
+                ['input' => [
+                    'type' => 'file',
+                    'name' => 'file',
+                    'id' => 'file',
+                    'class' => 'form-control',
+                ]],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testDefaultAlignFileControlWithError()
     {
         $this->article['errors'] = [

--- a/tests/TestCase/View/Helper/FormHelper/DefaultAlign/MultipleCheckboxControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/DefaultAlign/MultipleCheckboxControlTest.php
@@ -374,6 +374,34 @@ class MultipleCheckboxControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testDefaultAlignMultipleCheckboxControlWithCustomSpacing()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [],
+            'spacing' => 'custom-spacing',
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'custom-spacing form-group multicheckbox',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['label' => ['id' => 'users-group-label', 'class' => 'form-label d-block']],
+                    'Users',
+                '/label',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testDefaultAlignMultipleCheckboxControlWithError()
     {
         $this->article['errors'] = [
@@ -1582,6 +1610,99 @@ class MultipleCheckboxControlTest extends AbstractFormHelperTest
                     '/div',
                  '/fieldset',
                 ['fieldset' => ['class' => 'mb-3 form-group']],
+                    ['legend' => ['class' => 'col-form-label pt-0']],
+                        'group 2',
+                    '/legend',
+                    ['div' => ['class' => 'form-check']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-3',
+                            'value' => 3,
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-3']],
+                            'option 3',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'form-check']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-4',
+                            'value' => 4,
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-4']],
+                            'option 4',
+                        '/label',
+                    '/div',
+                 '/fieldset',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignMultipleCheckboxControlOptionGroupsWithCustomSpacing()
+    {
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                'group 1' => [
+                    1 => 'option 1',
+                    2 => 'option 2',
+                ],
+                'group 2' => [
+                    3 => 'option 3',
+                    4 => 'option 4',
+                ],
+            ],
+            'spacing' => 'custom-spacing',
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'custom-spacing form-group multicheckbox',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['label' => ['id' => 'users-group-label', 'class' => 'form-label d-block']],
+                    'Users',
+                '/label',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+                ['fieldset' => ['class' => 'custom-spacing form-group']],
+                    ['legend' => ['class' => 'col-form-label pt-0']],
+                        'group 1',
+                    '/legend',
+                    ['div' => ['class' => 'form-check']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-1',
+                            'value' => 1,
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                            'option 1',
+                        '/label',
+                    '/div',
+                    ['div' => ['class' => 'form-check']],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users[]',
+                            'id' => 'users-2',
+                            'value' => 2,
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                            'option 2',
+                        '/label',
+                    '/div',
+                 '/fieldset',
+                ['fieldset' => ['class' => 'custom-spacing form-group']],
                     ['legend' => ['class' => 'col-form-label pt-0']],
                         'group 2',
                     '/legend',

--- a/tests/TestCase/View/Helper/FormHelper/DefaultAlign/RadioControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/DefaultAlign/RadioControlTest.php
@@ -361,6 +361,34 @@ class RadioControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testDefaultAlignRadioControlWithCustomSpacing()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'type' => 'radio',
+            'options' => [],
+            'spacing' => 'custom-spacing',
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'custom-spacing form-group radio',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['label' => ['id' => 'users-group-label', 'class' => 'form-label d-block']],
+                    'Users',
+                '/label',
+                ['input' => [
+                    'type' => 'hidden',
+                    'name' => 'users',
+                    'value' => '',
+                ]],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testDefaultAlignRadioControlWithError()
     {
         $this->article['errors'] = [

--- a/tests/TestCase/View/Helper/FormHelper/DefaultAlign/RangeControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/DefaultAlign/RangeControlTest.php
@@ -240,6 +240,36 @@ class RangeControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testDefaultAlignRangeControlWithCustomSpacing()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('height', [
+            'type' => 'range',
+            'min' => 0,
+            'max' => 10,
+            'step' => 1,
+            'spacing' => 'custom-spacing',
+        ]);
+        $expected = [
+            'div' => ['class' => 'custom-spacing form-group range'],
+                ['label' => ['class' => 'form-label', 'for' => 'height']],
+                    'Height',
+                '/label',
+                'input' => [
+                    'type' => 'range',
+                    'name' => 'height',
+                    'min' => 0,
+                    'max' => 10,
+                    'step' => 1,
+                    'id' => 'height',
+                    'class' => 'form-range',
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testDefaultAlignRangeControlWithError()
     {
         $this->article['errors'] = [

--- a/tests/TestCase/View/Helper/FormHelper/DefaultAlign/SelectControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/DefaultAlign/SelectControlTest.php
@@ -280,6 +280,36 @@ class SelectControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testDefaultAlignSelectControlWithCustomSpacing()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('users', [
+            'type' => 'select',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'spacing' => 'custom-spacing',
+        ]);
+        $expected = [
+            'div' => ['class' => 'custom-spacing form-group select'],
+                ['label' => ['class' => 'form-label', 'for' => 'users']],
+                    'Users',
+                '/label',
+                ['select' => ['name' => 'users', 'id' => 'users', 'class' => 'form-select']],
+                    ['option' => ['value' => '1']],
+                        'option 1',
+                    '/option',
+                    ['option' => ['value' => '2']],
+                        'option 2',
+                    '/option',
+                '/select',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testDefaultAlignSelectControlWithError()
     {
         $this->article['errors'] = [

--- a/tests/TestCase/View/Helper/FormHelper/DefaultAlign/StaticControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/DefaultAlign/StaticControlTest.php
@@ -264,6 +264,35 @@ class StaticControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testDefaultAlignStaticControlWithCustomSpacing()
+    {
+        unset($this->article['required']['title']);
+        $this->article['defaults']['title'] = 'foo <u>bar</u>';
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('title', [
+            'type' => 'staticControl',
+            'spacing' => 'custom-spacing',
+        ]);
+        $expected = [
+            'div' => ['class' => 'custom-spacing form-group staticControl'],
+                ['label' => ['class' => 'form-label', 'for' => 'title']],
+                    'Title',
+                '/label',
+                'p' => ['class' => 'form-control-plaintext'],
+                    'foo &lt;u&gt;bar&lt;/u&gt;',
+                '/p',
+                'input' => [
+                    'type' => 'hidden',
+                    'name' => 'title',
+                    'id' => 'title',
+                    'value' => 'foo &lt;u&gt;bar&lt;/u&gt;',
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testDefaultAlignStaticControlWithError()
     {
         $this->article['errors'] = [

--- a/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/CheckboxControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/CheckboxControlTest.php
@@ -318,6 +318,47 @@ class CheckboxControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testHorizontalAlignCheckboxControlWithCustomSpacing()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    FormHelper::GRID_COLUMN_ONE => 5,
+                    FormHelper::GRID_COLUMN_TWO => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('users', [
+            'type' => 'checkbox',
+            'spacing' => 'custom-spacing',
+        ]);
+        $expected = [
+            ['div' => ['class' => 'custom-spacing form-group row checkbox']],
+                ['div' => ['class' => 'offset-sm-5 col-sm-7']],
+                    ['div' => ['class' => 'form-check']],
+                        ['input' => [
+                            'type' => 'hidden',
+                            'name' => 'users',
+                            'value' => 0,
+                        ]],
+                        ['input' => [
+                            'class' => 'form-check-input',
+                            'type' => 'checkbox',
+                            'name' => 'users',
+                            'id' => 'users',
+                            'value' => 1,
+                        ]],
+                        ['label' => ['class' => 'form-check-label', 'for' => 'users']],
+                            'Users',
+                        '/label',
+                    '/div',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testHorizontalAlignCheckboxControlWithError()
     {
         $this->article['errors'] = [

--- a/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/ColorControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/ColorControlTest.php
@@ -285,6 +285,41 @@ class ColorControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testHorizontalAlignColorControlWithCustomSpacing()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    FormHelper::GRID_COLUMN_ONE => 5,
+                    FormHelper::GRID_COLUMN_TWO => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('color', [
+            'type' => 'color',
+            'value' => '#ffffff',
+            'spacing' => 'custom-spacing',
+        ]);
+        $expected = [
+            'div' => ['class' => 'custom-spacing form-group row color'],
+                'label' => ['class' => 'col-form-label col-sm-5', 'for' => 'color'],
+                    'Color',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    'input' => [
+                        'type' => 'color',
+                        'name' => 'color',
+                        'id' => 'color',
+                        'class' => 'form-control form-control-color',
+                        'value' => '#ffffff',
+                    ],
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testHorizontalAlignColorControlWithError()
     {
         $this->article['errors'] = [

--- a/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/DateTimeControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/DateTimeControlTest.php
@@ -293,6 +293,43 @@ class DateTimeControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testHorizontalAlignDateTimeControlWithCustomSpacing()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    FormHelper::GRID_COLUMN_ONE => 5,
+                    FormHelper::GRID_COLUMN_TWO => 7,
+                ],
+            ],
+        ]);
+
+        $now = new \DateTime('now');
+
+        $result = $this->Form->control('created', [
+            'type' => 'datetime-local',
+            'value' => $now->format('Y-m-d H:i:s'),
+            'spacing' => 'custom-spacing',
+        ]);
+        $expected = [
+            ['div' => ['class' => 'custom-spacing form-group row datetime-local']],
+                ['label' => ['class' => 'col-form-label col-sm-5', 'for' => 'created']],
+                    'Created',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    'input' => [
+                        'type' => 'datetime-local',
+                        'name' => 'created',
+                        'id' => 'created',
+                        'class' => 'form-control',
+                        'value' => $now->format('Y-m-d H:i:s'),
+                    ],
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testHorizontalAlignDateTimeControlWithError()
     {
         $this->article['errors'] = [

--- a/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/FileControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/FileControlTest.php
@@ -266,6 +266,39 @@ class FileControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testHorizontalAlignFileControlWithCustomSpacing()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    FormHelper::GRID_COLUMN_ONE => 5,
+                    FormHelper::GRID_COLUMN_TWO => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('file', [
+            'type' => 'file',
+            'spacing' => 'custom-spacing',
+        ]);
+        $expected = [
+            ['div' => ['class' => 'custom-spacing form-group row file']],
+                ['label' => ['class' => 'col-form-label col-sm-5', 'for' => 'file']],
+                    'File',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    ['input' => [
+                        'type' => 'file',
+                        'name' => 'file',
+                        'id' => 'file',
+                        'class' => 'form-control',
+                    ]],
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testHorizontalAlignFileControlWithError()
     {
         $this->article['errors'] = [

--- a/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/MultipleCheckboxControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/MultipleCheckboxControlTest.php
@@ -446,6 +446,43 @@ class MultipleCheckboxControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testHorizontalAlignMultipleCheckboxControlWithCustomSpacing()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    FormHelper::GRID_COLUMN_ONE => 5,
+                    FormHelper::GRID_COLUMN_TWO => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [],
+            'spacing' => 'custom-spacing',
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'custom-spacing form-group row multicheckbox',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['label' => ['id' => 'users-group-label', 'class' => 'col-form-label col-sm-5 d-block pt-0']],
+                    'Users',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    ['input' => [
+                        'type' => 'hidden',
+                        'name' => 'users',
+                        'value' => '',
+                    ]],
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testHorizontalAlignMultipleCheckboxControlWithError()
     {
         $this->article['errors'] = [
@@ -1762,6 +1799,110 @@ class MultipleCheckboxControlTest extends AbstractFormHelperTest
                         '/div',
                      '/fieldset',
                     ['fieldset' => ['class' => 'mb-3 form-group']],
+                        ['legend' => ['class' => 'col-form-label pt-0']],
+                            'group 2',
+                        '/legend',
+                        ['div' => ['class' => 'form-check']],
+                            ['input' => [
+                                'class' => 'form-check-input',
+                                'type' => 'checkbox',
+                                'name' => 'users[]',
+                                'id' => 'users-3',
+                                'value' => 3,
+                            ]],
+                            ['label' => ['class' => 'form-check-label', 'for' => 'users-3']],
+                                'option 3',
+                            '/label',
+                        '/div',
+                        ['div' => ['class' => 'form-check']],
+                            ['input' => [
+                                'class' => 'form-check-input',
+                                'type' => 'checkbox',
+                                'name' => 'users[]',
+                                'id' => 'users-4',
+                                'value' => 4,
+                            ]],
+                            ['label' => ['class' => 'form-check-label', 'for' => 'users-4']],
+                                'option 4',
+                            '/label',
+                        '/div',
+                     '/fieldset',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignMultipleCheckboxControlOptionGroupsWithCustomSpacing()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    FormHelper::GRID_COLUMN_ONE => 5,
+                    FormHelper::GRID_COLUMN_TWO => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('users', [
+            'multiple' => 'checkbox',
+            'options' => [
+                'group 1' => [
+                    1 => 'option 1',
+                    2 => 'option 2',
+                ],
+                'group 2' => [
+                    3 => 'option 3',
+                    4 => 'option 4',
+                ],
+            ],
+            'spacing' => 'custom-spacing',
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'custom-spacing form-group row multicheckbox',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['label' => ['id' => 'users-group-label', 'class' => 'col-form-label col-sm-5 d-block pt-0']],
+                    'Users',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    ['input' => [
+                        'type' => 'hidden',
+                        'name' => 'users',
+                        'value' => '',
+                    ]],
+                    ['fieldset' => ['class' => 'custom-spacing form-group']],
+                        ['legend' => ['class' => 'col-form-label pt-0']],
+                            'group 1',
+                        '/legend',
+                        ['div' => ['class' => 'form-check']],
+                            ['input' => [
+                                'class' => 'form-check-input',
+                                'type' => 'checkbox',
+                                'name' => 'users[]',
+                                'id' => 'users-1',
+                                'value' => 1,
+                            ]],
+                            ['label' => ['class' => 'form-check-label', 'for' => 'users-1']],
+                                'option 1',
+                            '/label',
+                        '/div',
+                        ['div' => ['class' => 'form-check']],
+                            ['input' => [
+                                'class' => 'form-check-input',
+                                'type' => 'checkbox',
+                                'name' => 'users[]',
+                                'id' => 'users-2',
+                                'value' => 2,
+                            ]],
+                            ['label' => ['class' => 'form-check-label', 'for' => 'users-2']],
+                                'option 2',
+                            '/label',
+                        '/div',
+                     '/fieldset',
+                    ['fieldset' => ['class' => 'custom-spacing form-group']],
                         ['legend' => ['class' => 'col-form-label pt-0']],
                             'group 2',
                         '/legend',

--- a/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/RadioControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/RadioControlTest.php
@@ -425,6 +425,43 @@ class RadioControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testHorizontalAlignRadioControlWithCustomSpacing()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    FormHelper::GRID_COLUMN_ONE => 5,
+                    FormHelper::GRID_COLUMN_TWO => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('users', [
+            'type' => 'radio',
+            'options' => [],
+            'spacing' => 'custom-spacing',
+        ]);
+        $expected = [
+            ['div' => [
+                'class' => 'custom-spacing form-group row radio',
+                'role' => 'group',
+                'aria-labelledby' => 'users-group-label',
+            ]],
+                ['label' => ['id' => 'users-group-label', 'class' => 'col-form-label col-sm-5 d-block pt-0']],
+                    'Users',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    ['input' => [
+                        'type' => 'hidden',
+                        'name' => 'users',
+                        'value' => '',
+                    ]],
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testHorizontalAlignRadioControlWithError()
     {
         $this->article['errors'] = [

--- a/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/RangeControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/RangeControlTest.php
@@ -308,6 +308,45 @@ class RangeControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testHorizontalAlignRangeControlWithCustomSpacing()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    FormHelper::GRID_COLUMN_ONE => 5,
+                    FormHelper::GRID_COLUMN_TWO => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('height', [
+            'type' => 'range',
+            'min' => 0,
+            'max' => 10,
+            'step' => 1,
+            'spacing' => 'custom-spacing',
+        ]);
+        $expected = [
+            'div' => ['class' => 'custom-spacing form-group row range'],
+                ['label' => ['class' => 'col-form-label col-sm-5 pt-0', 'for' => 'height']],
+                    'Height',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    'input' => [
+                        'type' => 'range',
+                        'name' => 'height',
+                        'min' => 0,
+                        'max' => 10,
+                        'step' => 1,
+                        'id' => 'height',
+                        'class' => 'form-range',
+                    ],
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testHorizontalAlignRangeControlWithError()
     {
         $this->article['errors'] = [

--- a/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/SelectControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/SelectControlTest.php
@@ -357,6 +357,45 @@ class SelectControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testHorizontalAlignSelectControlWithCustomSpacing()
+    {
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    FormHelper::GRID_COLUMN_ONE => 5,
+                    FormHelper::GRID_COLUMN_TWO => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('users', [
+            'type' => 'select',
+            'options' => [
+                1 => 'option 1',
+                2 => 'option 2',
+            ],
+            'spacing' => 'custom-spacing',
+        ]);
+        $expected = [
+            ['div' => ['class' => 'custom-spacing form-group row select']],
+                ['label' => ['class' => 'col-form-label col-sm-5', 'for' => 'users']],
+                    'Users',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    ['select' => ['name' => 'users', 'id' => 'users', 'class' => 'form-select']],
+                        ['option' => ['value' => '1']],
+                            'option 1',
+                        '/option',
+                        ['option' => ['value' => '2']],
+                            'option 2',
+                        '/option',
+                    '/select',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testHorizontalAlignSelectControlWithError()
     {
         $this->article['errors'] = [

--- a/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/StaticControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/StaticControlTest.php
@@ -337,6 +337,44 @@ class StaticControlTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testHorizontalAlignStaticControlWithCustomSpacing()
+    {
+        unset($this->article['required']['title']);
+        $this->article['defaults']['title'] = 'foo <u>bar</u>';
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    FormHelper::GRID_COLUMN_ONE => 5,
+                    FormHelper::GRID_COLUMN_TWO => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('title', [
+            'type' => 'staticControl',
+            'spacing' => 'custom-spacing',
+        ]);
+        $expected = [
+            'div' => ['class' => 'custom-spacing form-group row staticControl'],
+                'label' => ['class' => 'col-form-label col-sm-5', 'for' => 'title'],
+                    'Title',
+                '/label',
+                ['div' => ['class' => 'col-sm-7']],
+                    'p' => ['class' => 'form-control-plaintext'],
+                        'foo &lt;u&gt;bar&lt;/u&gt;',
+                    '/p',
+                    'input' => [
+                        'type' => 'hidden',
+                        'name' => 'title',
+                        'id' => 'title',
+                        'value' => 'foo &lt;u&gt;bar&lt;/u&gt;',
+                    ],
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testHorizontalAlignStaticControlWithError()
     {
         $this->article['errors'] = [

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -582,7 +582,7 @@ class FormHelperTest extends AbstractFormHelperTest
     {
         $result = $this->Form->create($this->article, [
             'align' => 'inline',
-            'spacing' => 'custom-spacing'
+            'spacing' => 'custom-spacing',
         ]);
         $expected = [
             'form' => [

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -578,6 +578,24 @@ class FormHelperTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testInlineFormCreateWithCustomSpacing()
+    {
+        $result = $this->Form->create($this->article, [
+            'align' => 'inline',
+            'spacing' => 'custom-spacing'
+        ]);
+        $expected = [
+            'form' => [
+                'method' => 'post',
+                'accept-charset' => 'utf-8',
+                'role' => 'form',
+                'action' => '/articles/add',
+                'class' => 'form-inline row custom-spacing align-items-center',
+            ],
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testHorizontalFormCreate()
     {
         $result = $this->Form->create($this->article, ['align' => 'horizontal']);
@@ -1219,5 +1237,383 @@ class FormHelperTest extends AbstractFormHelperTest
             '/div',
         ];
         $this->assertHtml($expected, $result);
+    }
+
+    public function testSpacingViaCreateConfigIsBeingResetOnFormClose()
+    {
+        $this->article['required']['title'] = false;
+
+        $this->Form->create($this->article, [
+            'spacing' => 'custom-spacing-create',
+        ]);
+        $result = $this->Form->control('title');
+        $this->Form->end();
+
+        $expected = [
+            ['div' => ['class' => 'custom-spacing-create form-group text']],
+                ['label' => ['class' => 'form-label', 'for' => 'title']],
+                    'Title',
+                '/label',
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'title',
+                    'id' => 'title',
+                    'class' => 'form-control',
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $this->Form->create($this->article);
+        $result = $this->Form->control('title');
+        $this->Form->end();
+
+        $expected = [
+            ['div' => ['class' => 'mb-3 form-group text']],
+                ['label' => ['class' => 'form-label', 'for' => 'title']],
+                    'Title',
+                '/label',
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'title',
+                    'id' => 'title',
+                    'class' => 'form-control',
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testOverrideSpacingFromHelperConfigViaCreateConfig()
+    {
+        $this->article['required']['title'] = false;
+
+        $this->Form->setConfig([
+            'spacing' => 'custom-spacing-helper',
+        ]);
+
+        $this->Form->create($this->article);
+        $result = $this->Form->control('title');
+        $this->Form->end();
+
+        $expected = [
+            ['div' => ['class' => 'custom-spacing-helper form-group text']],
+                ['label' => ['class' => 'form-label', 'for' => 'title']],
+                    'Title',
+                '/label',
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'title',
+                    'id' => 'title',
+                    'class' => 'form-control',
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $this->Form->create($this->article, [
+            'spacing' => 'custom-spacing-create',
+        ]);
+        $result = $this->Form->control('title');
+        $this->Form->end();
+
+        $expected = [
+            ['div' => ['class' => 'custom-spacing-create form-group text']],
+                ['label' => ['class' => 'form-label', 'for' => 'title']],
+                    'Title',
+                '/label',
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'title',
+                    'id' => 'title',
+                    'class' => 'form-control',
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testOverrideSpacingFromHelperConfigViaControlConfig()
+    {
+        $this->article['required']['title'] = false;
+
+        $this->Form->setConfig([
+            'spacing' => 'custom-spacing-helper',
+        ]);
+
+        $this->Form->create($this->article);
+        $result = $this->Form->control('title');
+        $this->Form->end();
+
+        $expected = [
+            ['div' => ['class' => 'custom-spacing-helper form-group text']],
+                ['label' => ['class' => 'form-label', 'for' => 'title']],
+                    'Title',
+                '/label',
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'title',
+                    'id' => 'title',
+                    'class' => 'form-control',
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $this->Form->create($this->article);
+        $result = $this->Form->control('title', [
+            'spacing' => 'custom-spacing-control',
+        ]);
+        $this->Form->end();
+
+        $expected = [
+            ['div' => ['class' => 'custom-spacing-control form-group text']],
+                ['label' => ['class' => 'form-label', 'for' => 'title']],
+                    'Title',
+                '/label',
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'title',
+                    'id' => 'title',
+                    'class' => 'form-control',
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result, true);
+    }
+
+    public function testOverrideSpacingFromCreateConfigViaControlConfig()
+    {
+        $this->article['required']['title'] = false;
+
+        $this->Form->create($this->article, [
+            'spacing' => 'custom-spacing-create',
+        ]);
+        $result = $this->Form->control('title');
+
+        $expected = [
+            ['div' => ['class' => 'custom-spacing-create form-group text']],
+                ['label' => ['class' => 'form-label', 'for' => 'title']],
+                    'Title',
+                '/label',
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'title',
+                    'id' => 'title',
+                    'class' => 'form-control',
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Form->control('title', [
+            'spacing' => 'custom-spacing-control',
+        ]);
+        $expected = [
+            ['div' => ['class' => 'custom-spacing-control form-group text']],
+                ['label' => ['class' => 'form-label', 'for' => 'title']],
+                    'Title',
+                '/label',
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'title',
+                    'id' => 'title',
+                    'class' => 'form-control',
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result, true);
+
+        $this->Form->end();
+    }
+
+    public function testDisableSpacingViaHelperConfig()
+    {
+        $this->article['required']['title'] = false;
+
+        $this->Form->create($this->article);
+        $result = $this->Form->control('title');
+        $this->Form->end();
+
+        $expected = [
+            ['div' => ['class' => 'mb-3 form-group text']],
+                ['label' => ['class' => 'form-label', 'for' => 'title']],
+                    'Title',
+                '/label',
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'title',
+                    'id' => 'title',
+                    'class' => 'form-control',
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $this->Form->setConfig([
+            'spacing' => false,
+        ]);
+
+        $this->Form->create($this->article);
+        $result = $this->Form->control('title');
+        $this->Form->end();
+
+        $expected = [
+            ['div' => ['class' => 'form-group text']],
+                ['label' => ['class' => 'form-label', 'for' => 'title']],
+                    'Title',
+                '/label',
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'title',
+                    'id' => 'title',
+                    'class' => 'form-control',
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDisableSpacingFromHelperConfigViaCreateConfig()
+    {
+        $this->article['required']['title'] = false;
+
+        $this->Form->setConfig([
+            'spacing' => 'custom-spacing-helper',
+        ]);
+
+        $this->Form->create($this->article);
+        $result = $this->Form->control('title');
+        $this->Form->end();
+
+        $expected = [
+            ['div' => ['class' => 'custom-spacing-helper form-group text']],
+                ['label' => ['class' => 'form-label', 'for' => 'title']],
+                    'Title',
+                '/label',
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'title',
+                    'id' => 'title',
+                    'class' => 'form-control',
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $this->Form->create($this->article, [
+            'spacing' => false,
+        ]);
+        $result = $this->Form->control('title');
+        $this->Form->end();
+
+        $expected = [
+            ['div' => ['class' => 'form-group text']],
+                ['label' => ['class' => 'form-label', 'for' => 'title']],
+                    'Title',
+                '/label',
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'title',
+                    'id' => 'title',
+                    'class' => 'form-control',
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDisableSpacingFromHelperConfigViaControlConfig()
+    {
+        $this->article['required']['title'] = false;
+
+        $this->Form->setConfig([
+            'spacing' => 'custom-spacing-helper',
+        ]);
+
+        $this->Form->create($this->article);
+        $result = $this->Form->control('title');
+        $this->Form->end();
+
+        $expected = [
+            ['div' => ['class' => 'custom-spacing-helper form-group text']],
+                ['label' => ['class' => 'form-label', 'for' => 'title']],
+                    'Title',
+                '/label',
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'title',
+                    'id' => 'title',
+                    'class' => 'form-control',
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $this->Form->create($this->article);
+        $result = $this->Form->control('title', [
+            'spacing' => false,
+        ]);
+        $this->Form->end();
+
+        $expected = [
+            ['div' => ['class' => 'form-group text']],
+                ['label' => ['class' => 'form-label', 'for' => 'title']],
+                    'Title',
+                '/label',
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'title',
+                    'id' => 'title',
+                    'class' => 'form-control',
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result, true);
+    }
+
+    public function testDisableSpacingFromCreateConfigViaControlConfig()
+    {
+        $this->article['required']['title'] = false;
+
+        $this->Form->create($this->article, [
+            'spacing' => 'custom-spacing-create',
+        ]);
+        $result = $this->Form->control('title');
+
+        $expected = [
+            ['div' => ['class' => 'custom-spacing-create form-group text']],
+                ['label' => ['class' => 'form-label', 'for' => 'title']],
+                    'Title',
+                '/label',
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'title',
+                    'id' => 'title',
+                    'class' => 'form-control',
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Form->control('title', [
+            'spacing' => false,
+        ]);
+        $expected = [
+            ['div' => ['class' => 'form-group text']],
+                ['label' => ['class' => 'form-label', 'for' => 'title']],
+                    'Title',
+                '/label',
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'title',
+                    'id' => 'title',
+                    'class' => 'form-control',
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result, true);
+
+        $this->Form->end();
     }
 }


### PR DESCRIPTION
This adds support for configuring the spacing class used by the form helper, as suggested in https://github.com/FriendsOfCake/bootstrap-ui/issues/349#issuecomment-1013967857.

I'm still not overly convinced by it, as styling is so easily done in CSS, but I let others be the judge here. Please voice your opinions on it if you have any.

Only a few tests for now, but it should be enough to illustrate the possible usage of the feature.

/cc @gerhard-lechner 