### PR TITLE
4.x - Automatically generate placeholders for floating labels.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -5,6 +5,7 @@ namespace BootstrapUI\View\Helper;
 
 use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\Utility\Hash;
+use Cake\Utility\Inflector;
 use Cake\View\Helper\FormHelper as Helper;
 use Cake\View\View;
 use InvalidArgumentException;
@@ -559,6 +560,7 @@ class FormHelper extends Helper
         $options = $this->_containerOptions($fieldName, $options);
         $options = $this->_feedbackStyleOptions($fieldName, $options);
         $options = $this->_ariaOptions($fieldName, $options);
+        $options = $this->_placeholderOptions($fieldName, $options);
         $options = $this->_helpOptions($fieldName, $options);
         $options = $this->_tooltipOptions($fieldName, $options);
 
@@ -1034,6 +1036,40 @@ class FormHelper extends Helper
 
         if ($describedByIds) {
             $options['aria-describedby'] = $describedByIds;
+        }
+
+        return $options;
+    }
+
+    /**
+     * Modify options for placeholders.
+     *
+     * @param string $fieldName Field name.
+     * @param array $options Options. See `$options` argument of `control()` method.
+     * @return array
+     */
+    protected function _placeholderOptions(string $fieldName, array $options): array
+    {
+        if (
+            !isset($options['placeholder']) &&
+            isset($options['label']['floating']) &&
+            $options['label']['floating'] &&
+            in_array($options['type'], ['text', 'textarea'], true)
+        ) {
+            if (isset($options['label']['text'])) {
+                $options['placeholder'] = $options['label']['text'];
+            } else {
+                $text = $fieldName;
+                if (strpos($text, '.') !== false) {
+                    $fieldElements = explode('.', $text);
+                    $text = array_pop($fieldElements);
+                }
+                if (substr($text, -3) === '_id') {
+                    $text = substr($text, 0, -3);
+                }
+
+                $options['placeholder'] = __(Inflector::humanize(Inflector::underscore($text)));
+            }
         }
 
         return $options;

--- a/tests/TestCase/View/Helper/FormHelper/DefaultAlign/TextControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/DefaultAlign/TextControlTest.php
@@ -45,6 +45,90 @@ class TextControlTest extends AbstractFormHelperTest
                     'type' => 'text',
                     'name' => 'title',
                     'id' => 'title',
+                    'placeholder' => 'Title',
+                    'class' => 'form-control',
+                ],
+                ['label' => ['for' => 'title']],
+                    'Title',
+                '/label',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignTextControlWithFloatingLabelAndCustomLabelText()
+    {
+        unset($this->article['required']['title']);
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('title', [
+            'label' => [
+                'floating' => true,
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            'div' => ['class' => 'mb-3 form-floating form-group text'],
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'title',
+                    'id' => 'title',
+                    'placeholder' => 'Custom Label',
+                    'class' => 'form-control',
+                ],
+                ['label' => ['for' => 'title']],
+                    'Custom Label',
+                '/label',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignTextControlWithFloatingLabelAndCustomPlaceholder()
+    {
+        unset($this->article['required']['title']);
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('title', [
+            'label' => [
+                'floating' => true,
+            ],
+            'placeholder' => 'Custom Placeholder',
+        ]);
+        $expected = [
+            'div' => ['class' => 'mb-3 form-floating form-group text'],
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'title',
+                    'id' => 'title',
+                    'placeholder' => 'Custom Placeholder',
+                    'class' => 'form-control',
+                ],
+                ['label' => ['for' => 'title']],
+                    'Title',
+                '/label',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testDefaultAlignTextControlWithFloatingLabelAndDisabledPlaceholder()
+    {
+        unset($this->article['required']['title']);
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('title', [
+            'label' => [
+                'floating' => true,
+            ],
+            'placeholder' => false,
+        ]);
+        $expected = [
+            'div' => ['class' => 'mb-3 form-floating form-group text'],
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'title',
+                    'id' => 'title',
                     'class' => 'form-control',
                 ],
                 ['label' => ['for' => 'title']],

--- a/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/TextControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/HorizontalAlign/TextControlTest.php
@@ -63,6 +63,117 @@ class TextControlTest extends AbstractFormHelperTest
                         'type' => 'text',
                         'name' => 'title',
                         'id' => 'title',
+                        'placeholder' => 'Title',
+                        'class' => 'form-control',
+                    ],
+                    'label' => ['class' => 'ps-4', 'for' => 'title'],
+                        'Title',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignTextControlWithFloatingLabelAndCustomLabelText()
+    {
+        unset($this->article['required']['title']);
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    FormHelper::GRID_COLUMN_ONE => 5,
+                    FormHelper::GRID_COLUMN_TWO => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('title', [
+            'label' => [
+                'floating' => true,
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            'div' => ['class' => 'mb-3 form-group row text'],
+                ['div' => ['class' => 'offset-sm-5 col-sm-7 form-floating']],
+                    'input' => [
+                        'type' => 'text',
+                        'name' => 'title',
+                        'id' => 'title',
+                        'placeholder' => 'Custom Label',
+                        'class' => 'form-control',
+                    ],
+                    'label' => ['class' => 'ps-4', 'for' => 'title'],
+                        'Custom Label',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignTextControlWithFloatingLabelAndCustomPlaceholder()
+    {
+        unset($this->article['required']['title']);
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    FormHelper::GRID_COLUMN_ONE => 5,
+                    FormHelper::GRID_COLUMN_TWO => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('title', [
+            'label' => [
+                'floating' => true,
+            ],
+            'placeholder' => 'Custom Placeholder',
+        ]);
+        $expected = [
+            'div' => ['class' => 'mb-3 form-group row text'],
+                ['div' => ['class' => 'offset-sm-5 col-sm-7 form-floating']],
+                    'input' => [
+                        'type' => 'text',
+                        'name' => 'title',
+                        'id' => 'title',
+                        'placeholder' => 'Custom Placeholder',
+                        'class' => 'form-control',
+                    ],
+                    'label' => ['class' => 'ps-4', 'for' => 'title'],
+                        'Title',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testHorizontalAlignTextControlWithFloatingLabelAndDisabledPlaceholder()
+    {
+        unset($this->article['required']['title']);
+        $this->Form->create($this->article, [
+            'align' => [
+                'sm' => [
+                    FormHelper::GRID_COLUMN_ONE => 5,
+                    FormHelper::GRID_COLUMN_TWO => 7,
+                ],
+            ],
+        ]);
+
+        $result = $this->Form->control('title', [
+            'label' => [
+                'floating' => true,
+            ],
+            'placeholder' => false,
+        ]);
+        $expected = [
+            'div' => ['class' => 'mb-3 form-group row text'],
+                ['div' => ['class' => 'offset-sm-5 col-sm-7 form-floating']],
+                    'input' => [
+                        'type' => 'text',
+                        'name' => 'title',
+                        'id' => 'title',
                         'class' => 'form-control',
                     ],
                     'label' => ['class' => 'ps-4', 'for' => 'title'],

--- a/tests/TestCase/View/Helper/FormHelper/InlineAlign/TextControlTest.php
+++ b/tests/TestCase/View/Helper/FormHelper/InlineAlign/TextControlTest.php
@@ -52,6 +52,102 @@ class TextControlTest extends AbstractFormHelperTest
                         'type' => 'text',
                         'name' => 'title',
                         'id' => 'title',
+                        'placeholder' => 'Title',
+                        'class' => 'form-control',
+                    ],
+                    'label' => ['for' => 'title'],
+                        'Title',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testInlineAlignTextControlWithFloatingLabelAndCustomLabelText()
+    {
+        unset($this->article['required']['title']);
+        $this->Form->create($this->article, [
+            'align' => 'inline',
+        ]);
+
+        $result = $this->Form->control('title', [
+            'label' => [
+                'floating' => true,
+                'text' => 'Custom Label',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'col-auto']],
+                'div' => ['class' => 'form-floating form-group text'],
+                    'input' => [
+                        'type' => 'text',
+                        'name' => 'title',
+                        'id' => 'title',
+                        'placeholder' => 'Custom Label',
+                        'class' => 'form-control',
+                    ],
+                    'label' => ['for' => 'title'],
+                        'Custom Label',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testInlineAlignTextControlWithFloatingLabelAndCustomPlaceholder()
+    {
+        unset($this->article['required']['title']);
+        $this->Form->create($this->article, [
+            'align' => 'inline',
+        ]);
+
+        $result = $this->Form->control('title', [
+            'label' => [
+                'floating' => true,
+            ],
+            'placeholder' => 'Custom Placeholder',
+        ]);
+        $expected = [
+            ['div' => ['class' => 'col-auto']],
+                'div' => ['class' => 'form-floating form-group text'],
+                    'input' => [
+                        'type' => 'text',
+                        'name' => 'title',
+                        'id' => 'title',
+                        'placeholder' => 'Custom Placeholder',
+                        'class' => 'form-control',
+                    ],
+                    'label' => ['for' => 'title'],
+                        'Title',
+                    '/label',
+                '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testInlineAlignTextControlWithFloatingLabelAndDisabledPlaceholder()
+    {
+        unset($this->article['required']['title']);
+        $this->Form->create($this->article, [
+            'align' => 'inline',
+        ]);
+
+        $result = $this->Form->control('title', [
+            'label' => [
+                'floating' => true,
+            ],
+            'placeholder' => false,
+        ]);
+        $expected = [
+            ['div' => ['class' => 'col-auto']],
+                'div' => ['class' => 'form-floating form-group text'],
+                    'input' => [
+                        'type' => 'text',
+                        'name' => 'title',
+                        'id' => 'title',
                         'class' => 'form-control',
                     ],
                     'label' => ['for' => 'title'],

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -1616,4 +1616,85 @@ class FormHelperTest extends AbstractFormHelperTest
 
         $this->Form->end();
     }
+
+    public function testFloatingLabelPlaceholderGeneration()
+    {
+        $this->article['required']['title'] = false;
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('title', [
+            'label' => [
+                'floating' => true,
+            ],
+        ]);
+        $expected = [
+            'div' => ['class' => 'mb-3 form-floating form-group text'],
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'title',
+                    'id' => 'title',
+                    'placeholder' => 'Title',
+                    'class' => 'form-control',
+                ],
+                ['label' => ['for' => 'title']],
+                    'Title',
+                '/label',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testFloatingLabelPlaceholderGenerationForNestedField()
+    {
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('author.name', [
+            'label' => [
+                'floating' => true,
+            ],
+        ]);
+        $expected = [
+            'div' => ['class' => 'mb-3 form-floating form-group text'],
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'author[name]',
+                    'id' => 'author-name',
+                    'placeholder' => 'Name',
+                    'class' => 'form-control',
+                ],
+                ['label' => ['for' => 'author-name']],
+                    'Name',
+                '/label',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testFloatingLabelPlaceholderGenerationForIdField()
+    {
+        unset($this->article['required']['author_id']);
+        $this->Form->create($this->article);
+
+        $result = $this->Form->control('author_id', [
+            'type' => 'text',
+            'label' => [
+                'floating' => true,
+            ],
+        ]);
+        $expected = [
+            'div' => ['class' => 'mb-3 form-floating form-group text'],
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'author_id',
+                    'id' => 'author-id',
+                    'placeholder' => 'Author',
+                    'class' => 'form-control',
+                ],
+                ['label' => ['for' => 'author-id']],
+                    'Author',
+                '/label',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
 }


### PR DESCRIPTION
While this will not cover custom types, it should be good enough for most scenarios, eg use of `text` and `textarea` types.

The text inference is copied from the core, but without support for the special `_ids` key, as this would by default cause a `select` input to be generated, where placeholders do not apply.

Refs https://github.com/FriendsOfCake/bootstrap-ui/issues/349#issuecomment-1040063397 /cc @gerhard-lechner 
