### PR TITLE
Add default value in InputGroupTrait.php

### DIFF
--- a/src/View/Widget/InputGroupTrait.php
+++ b/src/View/Widget/InputGroupTrait.php
@@ -35,6 +35,7 @@ trait InputGroupTrait
             'injectFormControl' => true,
             'injectErrorClass' => null,
             'input' => null,
+            'templateVars' => null,
         ];
 
         if ($data['injectFormControl'] && $data['type'] !== 'hidden') {

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -521,6 +521,90 @@ class FormHelperTest extends AbstractFormHelperTest
         $this->assertHtml($expected, $result);
     }
 
+    public function testAddOnWithBasicInputs()
+    {
+        $this->article['required']['title'] = false;
+
+        $this->Form->create($this->article);
+
+        $result = $this->Form->text('title', ['prepend' => '@']);
+        $expected = [
+            ['div' => ['class' => 'input-group']],
+                'span' => ['class' => 'input-group-text'],
+                    '@',
+                '/span',
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'title',
+                    'class' => 'form-control',
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Form->textArea('title', ['prepend' => '@']);
+        $expected = [
+            ['div' => ['class' => 'input-group']],
+                'span' => ['class' => 'input-group-text'],
+                    '@',
+                '/span',
+                'textarea' => [
+                    'name' => 'title',
+                    'class' => 'form-control',
+                    'rows' => 5,
+                ],
+                '/textarea',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Form->select('title', [], ['prepend' => '@']);
+        $expected = [
+            ['div' => ['class' => 'input-group']],
+                'span' => ['class' => 'input-group-text'],
+                    '@',
+                '/span',
+                ['select' => ['name' => 'title', 'class' => 'form-select']],
+                    ['option' => ['value' => '']],
+                    '/option',
+                '/select',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Form->file('title', ['prepend' => '@']);
+        $expected = [
+            ['div' => ['class' => 'input-group']],
+                'span' => ['class' => 'input-group-text'],
+                    '@',
+                '/span',
+                'input' => [
+                    'type' => 'file',
+                    'name' => 'title',
+                    'class' => 'form-control',
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Form->dateTime('title', ['prepend' => '@']);
+        $expected = [
+            ['div' => ['class' => 'input-group']],
+                'span' => ['class' => 'input-group-text'],
+                    '@',
+                '/span',
+                'input' => [
+                    'type' => 'datetime-local',
+                    'name' => 'title',
+                    'class' => 'form-control',
+                    'step' => 1,
+                    'value' => '',
+                ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testFormCreate()
     {
         $result = $this->Form->create($this->article);


### PR DESCRIPTION
## Description
Adds a default null value for `templateVars` in `InputGroupTrait.php` so 
https://github.com/FriendsOfCake/bootstrap-ui/blob/6924ce44d72af0346998054f715907682210ffd7/src/View/Widget/InputGroupTrait.php#L83 does not print a notice that it is missing. 

Fixes https://github.com/FriendsOfCake/bootstrap-ui/issues/370
