### PR TITLE
Fix missing/incorrect `form-*` classes for `checkbox()` and `select()`.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -484,6 +484,17 @@ class FormHelper extends Helper
     }
 
     /**
+     * @inheritDoc
+     */
+    public function select(string $fieldName, iterable $options = [], array $attributes = []): string
+    {
+        $attributes['injectFormControl'] = false;
+        $attributes = $this->injectClasses('form-select', $attributes);
+
+        return parent::select($fieldName, $options, $attributes);
+    }
+
+    /**
      * {@inheritDoc}
      *
      * Additionally to the core form helper options, the following BootstrapUI related options are supported:
@@ -704,7 +715,6 @@ class FormHelper extends Helper
         if ($options['label'] !== false) {
             $options['label'] = $this->injectClasses('form-check-label', (array)$options['label']);
         }
-        $options = $this->injectClasses('form-check-input', $options);
 
         if ($this->_align === static::ALIGN_HORIZONTAL) {
             $options['inline'] = false;
@@ -848,11 +858,6 @@ class FormHelper extends Helper
 
         if ($labelClasses) {
             $options['label'] = $this->injectClasses($labelClasses, (array)$options['label']);
-        }
-
-        if ($options['type'] !== 'multicheckbox') {
-            $options['injectFormControl'] = false;
-            $options = $this->injectClasses('form-select', $options);
         }
 
         return $options;
@@ -1164,6 +1169,16 @@ class FormHelper extends Helper
         }
 
         return $html;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function checkbox(string $fieldName, array $options = [])
+    {
+        $options = $this->injectClasses('form-check-input', $options);
+
+        return parent::checkbox($fieldName, $options);
     }
 
     /**

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -851,11 +851,11 @@ class FormHelperTest extends AbstractFormHelperTest
     }
 
     /**
-     * Test that "form-control" class is added when using methods for specific input.
+     * Test that "form-*" classes are added when using methods for specific input.
      *
      * @return void
      */
-    public function testFormControlClassInjection()
+    public function testFormClassInjection()
     {
         $result = $this->Form->text('foo');
         $this->assertStringContainsString('class="form-control"', $result);
@@ -864,7 +864,8 @@ class FormHelperTest extends AbstractFormHelperTest
         $this->assertStringContainsString('class="custom form-control"', $result);
 
         $result = $this->Form->select('foo');
-        $this->assertStringContainsString('class="form-control"', $result);
+        $this->assertStringNotContainsString('"form-control"', $result);
+        $this->assertStringContainsString('class="form-select"', $result);
 
         $result = $this->Form->textarea('foo');
         $this->assertStringContainsString('class="form-control"', $result);
@@ -877,9 +878,11 @@ class FormHelperTest extends AbstractFormHelperTest
 
         $result = $this->Form->checkbox('foo');
         $this->assertStringNotContainsString('"form-control"', $result);
+        $this->assertStringContainsString('class="form-check-input"', $result);
 
         $result = $this->Form->radio('foo', ['1' => 'Opt 1', '2' => 'Opt 2']);
         $this->assertStringNotContainsString('"form-control"', $result);
+        $this->assertStringContainsString('class="form-check-input"', $result);
 
         $result = $this->Form->color('foo');
         $this->assertStringContainsString('class="form-control form-control-color"', $result);


### PR DESCRIPTION
fixes #369
