### PR TITLE
Fix dashboard layout closing elements.

### DIFF
--- a/templates/layout/examples/dashboard.php
+++ b/templates/layout/examples/dashboard.php
@@ -62,9 +62,12 @@ if (!$this->fetch('tb_flash')) {
 $this->end();
 
 $this->start('tb_body_end');
-echo '</body>';
+?>
+            </main>
+        </div>
+    </div>
+</body>
+<?php
 $this->end();
 
 echo $this->fetch('content');
-
-$this->append('footer', '</main></div></div>');


### PR DESCRIPTION
This will cause the footer to be placed before the closing `</main>` element, which is probably the best position in that layout, as otherwise it can easily break.

The side effect is that scripts will be placed there too, but that shouldn't cause any problems.

![image](https://user-images.githubusercontent.com/5031606/206033968-73872abb-8bcf-48cc-a5a6-088ff3880004.png)

Fixes #379
