### PR TITLE
Fix up null issue

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -647,7 +647,7 @@ class FormHelper extends CoreFormHelper
             isset($options['type']) &&
             $options['spacing'] !== false
         ) {
-            $options['container'] = $this->injectClasses($options['spacing'], (array)($options['container'] ?? []));
+            $options['container'] = $this->injectClasses($options['spacing'] ?? [], (array)($options['container'] ?? []));
         }
 
         if (

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -647,7 +647,9 @@ class FormHelper extends CoreFormHelper
             isset($options['type']) &&
             $options['spacing'] !== false
         ) {
-            $options['container'] = $this->injectClasses($options['spacing'] ?? [], (array)($options['container'] ?? []));
+            $classes = $options['spacing'] ?? [];
+            $options = (array)($options['container'] ?? []);
+            $options['container'] = $this->injectClasses($classes, $options);
         }
 
         if (


### PR DESCRIPTION
In my case there was a type error:

> 1) App\Test\TestCase\Controller\MiscControllerTest::testConvertText
TypeError: BootstrapUI\View\Helper\FormHelper::injectClasses(): Argument # 1 ($classes) must be of type array|string, null given, called in /work/devilbox/data/www/sandbox/vendor/friendsofcake/bootstrap-ui/src/View/Helper/FormHelper.php on line 650

Can be avoided by defaulting it to a valid type
