### PR TITLE
Fixes #394 - Removes role="form" from form tags.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ webroot/js/*
 nbproject/*
 # Visual Studio Code
 .vscode
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ echo $this->Form->end();
 will render this HTML:
 
 ```html
-<form method="post" accept-charset="utf-8" role="form" action="/articles/add">
+<form method="post" accept-charset="utf-8" action="/articles/add">
     <!-- ... -->
     <div class="mb-3 form-group text">
         <label class="form-label" for="title">Title</label>
@@ -365,7 +365,7 @@ echo $this->Form->end();
 It will render this HTML:
 
 ```html
-<form method="post" accept-charset="utf-8" class="form-horizontal" role="form" action="/articles/add">
+<form method="post" accept-charset="utf-8" class="form-horizontal" action="/articles/add">
     <!-- ... -->
     <div class="mb-3 form-group row text">
         <label class="col-form-label col-md-4" for="title">Title</label>
@@ -413,7 +413,7 @@ echo $this->Form->end();
 It will render this HTML:
 
 ```html
-<form method="post" accept-charset="utf-8" class="form-horizontal" role="form" action="/articles/add">
+<form method="post" accept-charset="utf-8" class="form-horizontal" action="/articles/add">
     <!-- ... -->
     <div class="mb-3 form-group row text">
         <label class="col-form-label col-sm-6 col-md-4" for="title">Title</label>
@@ -459,7 +459,7 @@ echo $this->Form->end();
 will render this HTML:
 
 ```html
-<form method="post" accept-charset="utf-8" class="form-inline" role="form" action="/articles/add">
+<form method="post" accept-charset="utf-8" class="form-inline" action="/articles/add">
     <!-- ... -->
     <div class="form-group text">
         <label class="form-label visually-hidden" for="title">Title</label>

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -406,7 +406,6 @@ class FormHelper extends CoreFormHelper
     {
         $options += [
             'class' => null,
-            'role' => 'form',
             'align' => null,
             'templates' => [],
             'spacing' => null,

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -612,7 +612,6 @@ class FormHelperTest extends AbstractFormHelperTest
             'form' => [
                 'method' => 'post',
                 'accept-charset' => 'utf-8',
-                'role' => 'form',
                 'action' => '/articles/add',
             ],
         ];
@@ -654,7 +653,6 @@ class FormHelperTest extends AbstractFormHelperTest
             'form' => [
                 'method' => 'post',
                 'accept-charset' => 'utf-8',
-                'role' => 'form',
                 'action' => '/articles/add',
                 'class' => 'form-inline row g-3 align-items-center',
             ],
@@ -672,7 +670,6 @@ class FormHelperTest extends AbstractFormHelperTest
             'form' => [
                 'method' => 'post',
                 'accept-charset' => 'utf-8',
-                'role' => 'form',
                 'action' => '/articles/add',
                 'class' => 'form-inline row custom-spacing align-items-center',
             ],
@@ -687,7 +684,6 @@ class FormHelperTest extends AbstractFormHelperTest
             'form' => [
                 'method' => 'post',
                 'accept-charset' => 'utf-8',
-                'role' => 'form',
                 'action' => '/articles/add',
                 'class' => 'form-horizontal',
             ],
@@ -788,7 +784,6 @@ class FormHelperTest extends AbstractFormHelperTest
             'form' => [
                 'method' => 'post',
                 'accept-charset' => 'utf-8',
-                'role' => 'form',
                 'action' => '/articles/add',
                 'class' => 'form-horizontal',
             ],


### PR DESCRIPTION
## Description
Removes role="form" from form tags.

## Summarize
Write a list of the changes that were made.

- Updated FormHelper to remove role="form"
- Updated tests.

## Benefits
Role="form" is not needed for the form tag.
Html validators will throw a notification when this is found.

## Related Issues
This PR addresses the following issues.

fixes #394
