### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1340,13 +1340,9 @@ composer install
 
 https://github.com/friendsofcake/bootstrap-ui/issues
 
-## License
-
-Copyright (c) 2015, Jad Bitar and licensed under [The MIT License][mit].
 
 [cakephp]:https://cakephp.org/
 [composer]:https://getcomposer.org/
 [composer:ignore]:https://getcomposer.org/doc/faqs/should-i-commit-the-dependencies-in-my-vendor-directory.md
-[mit]:https://opensource.org/licenses/mit-license.php
 [bs]:https://getbootstrap.com/
 [npm]:https://www.npmjs.com/


### PR DESCRIPTION
License is now metioned and linked directly in the header row besides the name
twice, including the badge