### PR TITLE
Update classes used by HtmlHelper::badge().

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -54,7 +54,7 @@ class HtmlHelper extends CoreHtmlHelper
         $tag = $options['tag'];
         unset($options['tag']);
 
-        $allClasses = $this->genAllClassNames('bg');
+        $allClasses = $this->genAllClassNames('text-bg');
 
         if ($this->hasAnyClass($allClasses, $options)) {
             $options = $this->injectClasses('badge', $options);
@@ -62,7 +62,7 @@ class HtmlHelper extends CoreHtmlHelper
             $options = $this->injectClasses(['badge', 'secondary'], $options);
         }
 
-        $classes = $this->renameClasses('bg', $options);
+        $classes = $this->renameClasses('text-bg', $options);
 
         return $this->tag($tag, $text, $classes);
     }

--- a/src/View/Helper/Types/Element.php
+++ b/src/View/Helper/Types/Element.php
@@ -16,6 +16,8 @@ final class Element extends Type
     public const BADGE = 'badge';
     /** @var string The bg (background) element */
     public const BG = 'bg';
+    /** @var string The text bg (background) element */
+    public const TEXT_BG = 'text-bg';
     /** @var string The border element */
     public const BORDER = 'border';
     /** @var string The button element */

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -37,7 +37,7 @@ class HtmlHelperTest extends TestCase
     {
         $result = $this->Html->badge('foo');
         $expected = [
-            'span' => ['class' => 'badge bg-secondary'],
+            'span' => ['class' => 'badge text-bg-secondary'],
             'foo',
             '/span',
         ];
@@ -45,7 +45,7 @@ class HtmlHelperTest extends TestCase
 
         $result = $this->Html->badge('foo', ['class' => 'primary']);
         $expected = [
-            'span' => ['class' => 'bg-primary badge'],
+            'span' => ['class' => 'text-bg-primary badge'],
             'foo',
             '/span',
         ];

--- a/tests/TestCase/View/Helper/Types/ElementTest.php
+++ b/tests/TestCase/View/Helper/Types/ElementTest.php
@@ -23,6 +23,7 @@ class ElementTest extends TestCase
             Element::ALERT,
             Element::BADGE,
             Element::BG,
+            Element::TEXT_BG,
             Element::BORDER,
             Element::BTN,
             Element::BTN_OUTLINE,


### PR DESCRIPTION
Use the the new `text-bg-*` classes instead of `bg-*` classes.
https://getbootstrap.com/docs/5.3/components/badge/#background-colors
