### PR TITLE
Update boostrap to v5.3 and bootstrap-icons to v1.11.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,9 @@ For version info see [version map](https://github.com/FriendsOfCake/bootstrap-ui
 ## Requirements
 
 * CakePHP 5.x
-* Bootstrap 5.x
+* Bootstrap 5.3.x
 * npm 6.x
-* Popper.js 2.x
-* Bootstrap Icons 1.5.x
+* Bootstrap Icons 1.11.x
 
 ## What's included?
 
@@ -72,7 +71,7 @@ You can either use the Bootstrap commands to make the necessary changes, or do t
 
 ### Using the Bootstrap commands
 
-1. To install the Bootstrap assets (Bootstrap's CSS/JS files, Popper.js) via npm you can use the `install`
+1. To install the Bootstrap assets (Bootstrap's CSS/JS files) via npm you can use the `install`
    command, or [install them manually](#installing-bootstrap-assets-via-npm):
 
    ```
@@ -119,16 +118,14 @@ do manually if you wish to control which assets are being included, and where th
 Assuming you are in your application's root:
 
 ```
-npm install @popperjs/core@2 bootstrap@5 bootstrap-icons@1
+npm install bootstrap@5 bootstrap-icons@1
 mkdir -p webroot/css
 mkdir -p webroot/font/fonts
 mkdir -p webroot/js
-cp node_modules/@popperjs/core/dist/umd/popper.js webroot/js
-cp node_modules/@popperjs/core/dist/umd/popper.min.js webroot/js
 cp node_modules/bootstrap/dist/css/bootstrap.css webroot/css/
 cp node_modules/bootstrap/dist/css/bootstrap.min.css webroot/css/
-cp node_modules/bootstrap/dist/js/bootstrap.js webroot/js/
-cp node_modules/bootstrap/dist/js/bootstrap.min.js webroot/js/
+cp node_modules/bootstrap/dist/js/bootstrap.bundle.js webroot/js/
+cp node_modules/bootstrap/dist/js/bootstrap.bundle.min.js webroot/js/
 cp node_modules/bootstrap-icons/font/bootstrap-icons.css webroot/font/
 cp node_modules/bootstrap-icons/font/fonts/bootstrap-icons.woff webroot/font/fonts/
 cp node_modules/bootstrap-icons/font/fonts/bootstrap-icons.woff2 webroot/font/fonts/
@@ -245,7 +242,7 @@ them using the standard plugin syntax:
 // in the <head>
 echo $this->Html->css('BootstrapUI.bootstrap.min');
 echo $this->Html->css(['BootstrapUI./font/bootstrap-icons', 'BootstrapUI./font/bootstrap-icon-sizes']);
-echo $this->Html->script(['BootstrapUI.popper.min', 'BootstrapUI.bootstrap.min']);
+echo $this->Html->script(['BootstrapUI.bootstrap.bundle.min']);
 ```
 
 If you have installed the assets manually, you'll need to use paths accordingly. With
@@ -254,7 +251,7 @@ If you have installed the assets manually, you'll need to use paths accordingly.
 ```php
 echo $this->Html->css('bootstrap.min');
 echo $this->Html->css(['/font/bootstrap-icons', '/font/bootstrap-icon-sizes']);
-echo $this->Html->script(['popper.min', 'bootstrap.min']);
+echo $this->Html->script(['bootstrap.bundle.min']);
 ```
 
 If you're using paths that don't adhere to the CakePHP conventions, you'll have to explicitly specify them:
@@ -262,7 +259,7 @@ If you're using paths that don't adhere to the CakePHP conventions, you'll have 
 ```php
 echo $this->Html->css('/path/to/bootstrap.css');
 echo $this->Html->css(['/path/to/bootstrap-icons.css', '/path/to/bootstrap-icon-sizes.css']);
-echo $this->Html->script(['/path/to/popper.js', '/path/to/bootstrap.js']);
+echo $this->Html->script(['/path/to/bootstrap.bundle.js']);
 ```
 
 ## Bake templates
@@ -343,7 +340,7 @@ Horizontal forms automatically render labels and controls in separate columns (w
 one, and controls in the second one.
 
 Alignment can be configured via the `align` option, which takes either a list of column sizes for the `md`
-[Bootstrap screen-size/breakpoint](https://getbootstrap.com/docs/5.0/layout/breakpoints/), or a matrix of
+[Bootstrap screen-size/breakpoint](https://getbootstrap.com/docs/5.3/layout/breakpoints/), or a matrix of
 screen-size/breakpoint names and column sizes.
 
 The following will use the default `md` screen-size/breakpoint:
@@ -477,8 +474,8 @@ will render this HTML:
 ### Spacing
 
 Out of the box BootstrapUI applies some default spacing for form controls. For default and horizontal aligned forms,
-the `mb-3` [spacing class](https://getbootstrap.com/docs/5.0/utilities/spacing/) is being applied to all controls,
-while inline forms are using the `g-3` [gutter class](https://getbootstrap.com/docs/5.0/layout/gutters/).
+the `mb-3` [spacing class](https://getbootstrap.com/docs/5.3/utilities/spacing/) is being applied to all controls,
+while inline forms are using the `g-3` [gutter class](https://getbootstrap.com/docs/5.3/layout/gutters/).
 
 This can be changed using the `spacing` option, it applies on a per-helper and per-form basis for all alignments, and
 for default/horizontal alignments it also applies on a per-control basis.
@@ -655,7 +652,7 @@ This would generate the following HTML:
 
 ### Switches
 
-[Switch style checkboxes](https://getbootstrap.com/docs/5.0/forms/checks-radios/#switches) can be created by setting the
+[Switch style checkboxes](https://getbootstrap.com/docs/5.3/forms/checks-radios/#switches) can be created by setting the
 `switch` option to `true`.
 
 ```php
@@ -677,7 +674,7 @@ This would generate the following HTML:
 
 ### Floating labels
 
-[Floating labels](https://getbootstrap.com/docs/5.0/forms/floating-labels) are supported for `text`, `textarea`, and
+[Floating labels](https://getbootstrap.com/docs/5.3/forms/floating-labels) are supported for `text`, `textarea`, and
 (non-`multiple`) `select` controls. They can be enabled via the label's `floating` option:
 
 ```php
@@ -746,7 +743,7 @@ This would generate the following HTML:
 
 ### Tooltips
 
-[Bootstrap tooltips](https://getbootstrap.com/docs/5.0/components/tooltips/) can be added to labels via the `tooltip`
+[Bootstrap tooltips](https://getbootstrap.com/docs/5.3/components/tooltips/) can be added to labels via the `tooltip`
 option. The tooltip toggles are by default being rendered as a [Bootstrap icon](https://icons.getbootstrap.com/), which
 is being included by default when installing the assets via the `install` command.
 
@@ -1001,7 +998,7 @@ echo $this->Html->badge('Text');
 
 #### Background colors
 
-[Background colors](https://getbootstrap.com/docs/5.0/components/badge/#background-colors) can be changed by specifying
+[Background colors](https://getbootstrap.com/docs/5.3/components/badge/#background-colors) can be changed by specifying
 one of the Bootstrap theme color names via the `class` option, the helper will make sure that the correct prefixes
 are being applied:
 
@@ -1155,7 +1152,7 @@ This would generate the following HTML:
 #### Configuring the ARIA labels
 
 When using the standard methods you can use the `label` option to pass a custom string to use for
-[the `aria-label` attribute](https://getbootstrap.com/docs/5.0/components/pagination/#working-with-icons):
+[the `aria-label` attribute](https://getbootstrap.com/docs/5.3/components/pagination/#working-with-icons):
 
 ```php
 echo $this->Paginator->first('«', ['label' => __('Beginning')]);
@@ -1276,7 +1273,7 @@ This would generate the following HTML:
 
 ##### Sizing
 
-[The size](https://getbootstrap.com/docs/5.0/components/pagination/#sizing) can be specified via the `size` option:
+[The size](https://getbootstrap.com/docs/5.3/components/pagination/#sizing) can be specified via the `size` option:
 
 ```php
 echo $this->Paginator->links([

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,57 +5,71 @@
     "packages": {
         "": {
             "dependencies": {
-                "@popperjs/core": "^2.9.2",
-                "bootstrap": "^5.0.1",
-                "bootstrap-icons": "^1.5.0"
+                "bootstrap": "^5.3.3",
+                "bootstrap-icons": "^1.11.3"
             }
         },
         "node_modules/@popperjs/core": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.2.tgz",
-            "integrity": "sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==",
+            "version": "2.11.8",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
             }
         },
         "node_modules/bootstrap": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.0.1.tgz",
-            "integrity": "sha512-Fl79+wsLOZKoiU345KeEaWD0ik8WKRI5zm0YSPj2oF1Qr+BO7z0fco6GbUtqjoG1h4VI89PeKJnMsMMVQdKKTw==",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/bootstrap"
-            },
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+            "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/twbs"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/bootstrap"
+                }
+            ],
             "peerDependencies": {
-                "@popperjs/core": "^2.9.2"
+                "@popperjs/core": "^2.11.8"
             }
         },
         "node_modules/bootstrap-icons": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.5.0.tgz",
-            "integrity": "sha512-44feMc7DE1Ccpsas/1wioN8ewFJNquvi5FewA06wLnqct7CwMdGDVy41ieHaacogzDqLfG8nADIvMNp9e4bfbA==",
-            "engines": {
-                "node": ">=10"
-            }
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.11.3.tgz",
+            "integrity": "sha512-+3lpHrCw/it2/7lBL15VR0HEumaBss0+f/Lb6ZvHISn1mlK83jjFpooTLsMWbIjJMDjDjOExMsTxnXSIT4k4ww==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/twbs"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/bootstrap"
+                }
+            ]
         }
     },
     "dependencies": {
         "@popperjs/core": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.2.tgz",
-            "integrity": "sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q=="
+            "version": "2.11.8",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+            "peer": true
         },
         "bootstrap": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.0.1.tgz",
-            "integrity": "sha512-Fl79+wsLOZKoiU345KeEaWD0ik8WKRI5zm0YSPj2oF1Qr+BO7z0fco6GbUtqjoG1h4VI89PeKJnMsMMVQdKKTw==",
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+            "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
             "requires": {}
         },
         "bootstrap-icons": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.5.0.tgz",
-            "integrity": "sha512-44feMc7DE1Ccpsas/1wioN8ewFJNquvi5FewA06wLnqct7CwMdGDVy41ieHaacogzDqLfG8nADIvMNp9e4bfbA=="
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.11.3.tgz",
+            "integrity": "sha512-+3lpHrCw/it2/7lBL15VR0HEumaBss0+f/Lb6ZvHISn1mlK83jjFpooTLsMWbIjJMDjDjOExMsTxnXSIT4k4ww=="
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
     "dependencies": {
-        "@popperjs/core": "^2.9.2",
-        "bootstrap": "^5.0.1",
-        "bootstrap-icons": "^1.5.0"
+        "bootstrap": "^5.3.3",
+        "bootstrap-icons": "^1.11.3"
     }
 }

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -352,7 +352,6 @@ class InstallCommand extends Command
 
         $nodeModulesPath = Plugin::path('BootstrapUI') . 'node_modules' . DS;
         $paths = [
-            $nodeModulesPath . '@popperjs/core/dist/umd',
             $nodeModulesPath . 'bootstrap/dist',
             $nodeModulesPath . 'bootstrap-icons',
         ];

--- a/templates/layout/default.php
+++ b/templates/layout/default.php
@@ -93,12 +93,12 @@ $this->prepend(
 
 /**
  * Prepend `script` block with Popper and Bootstrap scripts
- * Change popper.min and bootstrap.min to use the compressed version
+ * Change bootstrap.min to use the compressed version
  */
 if (Configure::read('debug')) {
-    $this->prepend('script', $this->Html->script(['BootstrapUI.popper', 'BootstrapUI.bootstrap']));
+    $this->prepend('script', $this->Html->script(['BootstrapUI.bootstrap.bundle']));
 } else {
-    $this->prepend('script', $this->Html->script(['BootstrapUI.popper.min', 'BootstrapUI.bootstrap.min']));
+    $this->prepend('script', $this->Html->script(['BootstrapUI.bootstrap.bundle.min']));
 }
 
 ?>

--- a/tests/TestCase/Command/InstallCommandTest.php
+++ b/tests/TestCase/Command/InstallCommandTest.php
@@ -53,14 +53,10 @@ class InstallCommandTest extends TestCase
             'fonts' . DS . 'bootstrap-icons.woff2',
         ];
         $jsAssets = [
-            'bootstrap.js',
-            'bootstrap.js.map',
-            'bootstrap.min.js',
-            'bootstrap.min.js.map',
-            'popper.js',
-            'popper.js.map',
-            'popper.min.js',
-            'popper.min.js.map',
+            'bootstrap.bundle.js',
+            'bootstrap.bundle.js.map',
+            'bootstrap.bundle.min.js',
+            'bootstrap.bundle.min.js.map',
         ];
 
         foreach ($cssAssets as $asset) {
@@ -89,10 +85,10 @@ class InstallCommandTest extends TestCase
             '<success>`bootstrap.css.map` successfully deleted.</success>',
             '<success>`bootstrap.min.css` successfully deleted.</success>',
             '<success>`bootstrap.min.css.map` successfully deleted.</success>',
-            '<success>`bootstrap.js` successfully deleted.</success>',
-            '<success>`bootstrap.js.map` successfully deleted.</success>',
-            '<success>`bootstrap.min.js` successfully deleted.</success>',
-            '<success>`bootstrap.min.js.map` successfully deleted.</success>',
+            '<success>`bootstrap.bundle.js` successfully deleted.</success>',
+            '<success>`bootstrap.bundle.js.map` successfully deleted.</success>',
+            '<success>`bootstrap.bundle.min.js` successfully deleted.</success>',
+            '<success>`bootstrap.bundle.min.js.map` successfully deleted.</success>',
             '<success>`popper.js` successfully deleted.</success>',
             '<success>`popper.js.map` successfully deleted.</success>',
             '<success>`popper.min.js` successfully deleted.</success>',
@@ -106,10 +102,10 @@ class InstallCommandTest extends TestCase
             '<success>`bootstrap.css.map` successfully copied.</success>',
             '<success>`bootstrap.min.css` successfully copied.</success>',
             '<success>`bootstrap.min.css.map` successfully copied.</success>',
-            '<success>`bootstrap.js` successfully copied.</success>',
-            '<success>`bootstrap.js.map` successfully copied.</success>',
-            '<success>`bootstrap.min.js` successfully copied.</success>',
-            '<success>`bootstrap.min.js.map` successfully copied.</success>',
+            '<success>`bootstrap.bundle.js` successfully copied.</success>',
+            '<success>`bootstrap.bundle.js.map` successfully copied.</success>',
+            '<success>`bootstrap.bundle.min.js` successfully copied.</success>',
+            '<success>`bootstrap.bundle.min.js.map` successfully copied.</success>',
             '<success>`popper.js` successfully copied.</success>',
             '<success>`popper.js.map` successfully copied.</success>',
             '<success>`popper.min.js` successfully copied.</success>',
@@ -131,10 +127,10 @@ class InstallCommandTest extends TestCase
             '<success>`bootstrap.css.map` successfully deleted.</success>',
             '<success>`bootstrap.min.css` successfully deleted.</success>',
             '<success>`bootstrap.min.css.map` successfully deleted.</success>',
-            '<success>`bootstrap.js` successfully deleted.</success>',
-            '<success>`bootstrap.js.map` successfully deleted.</success>',
-            '<success>`bootstrap.min.js` successfully deleted.</success>',
-            '<success>`bootstrap.min.js.map` successfully deleted.</success>',
+            '<success>`bootstrap.bundle.js` successfully deleted.</success>',
+            '<success>`bootstrap.bundle.js.map` successfully deleted.</success>',
+            '<success>`bootstrap.bundle.min.js` successfully deleted.</success>',
+            '<success>`bootstrap.bundle.min.js.map` successfully deleted.</success>',
             '<success>`popper.js` successfully deleted.</success>',
             '<success>`popper.js.map` successfully deleted.</success>',
             '<success>`popper.min.js` successfully deleted.</success>',
@@ -146,10 +142,10 @@ class InstallCommandTest extends TestCase
             '<success>`bootstrap.css.map` successfully copied.</success>',
             '<success>`bootstrap.min.css` successfully copied.</success>',
             '<success>`bootstrap.min.css.map` successfully copied.</success>',
-            '<success>`bootstrap.js` successfully copied.</success>',
-            '<success>`bootstrap.js.map` successfully copied.</success>',
-            '<success>`bootstrap.min.js` successfully copied.</success>',
-            '<success>`bootstrap.min.js.map` successfully copied.</success>',
+            '<success>`bootstrap.bundle.js` successfully copied.</success>',
+            '<success>`bootstrap.bundle.js.map` successfully copied.</success>',
+            '<success>`bootstrap.bundle.min.js` successfully copied.</success>',
+            '<success>`bootstrap.bundle.min.js.map` successfully copied.</success>',
             '<success>`popper.js` successfully copied.</success>',
             '<success>`popper.js.map` successfully copied.</success>',
             '<success>`popper.min.js` successfully copied.</success>',
@@ -188,14 +184,10 @@ class InstallCommandTest extends TestCase
             'fonts' . DS . 'bootstrap-icons.woff2',
         ];
         $jsAssets = [
-            'bootstrap.js',
-            'bootstrap.js.map',
-            'bootstrap.min.js',
-            'bootstrap.min.js.map',
-            'popper.js',
-            'popper.js.map',
-            'popper.min.js',
-            'popper.min.js.map',
+            'bootstrap.bundle.js',
+            'bootstrap.bundle.js.map',
+            'bootstrap.bundle.min.js',
+            'bootstrap.bundle.min.js.map',
         ];
 
         foreach ($cssAssets as $asset) {
@@ -261,14 +253,10 @@ class InstallCommandTest extends TestCase
             '<success>`bootstrap.css.map` successfully deleted.</success>',
             '<success>`bootstrap.min.css` successfully deleted.</success>',
             '<success>`bootstrap.min.css.map` successfully deleted.</success>',
-            '<success>`bootstrap.js` successfully deleted.</success>',
-            '<success>`bootstrap.js.map` successfully deleted.</success>',
-            '<success>`bootstrap.min.js` successfully deleted.</success>',
-            '<success>`bootstrap.min.js.map` successfully deleted.</success>',
-            '<success>`popper.js` successfully deleted.</success>',
-            '<success>`popper.js.map` successfully deleted.</success>',
-            '<success>`popper.min.js` successfully deleted.</success>',
-            '<success>`popper.min.js.map` successfully deleted.</success>',
+            '<success>`bootstrap.bundle.js` successfully deleted.</success>',
+            '<success>`bootstrap.bundle.js.map` successfully deleted.</success>',
+            '<success>`bootstrap.bundle.min.js` successfully deleted.</success>',
+            '<success>`bootstrap.bundle.min.js.map` successfully deleted.</success>',
             '<success>`bootstrap-icons.css` successfully deleted.</success>',
             '<success>`bootstrap-icons.woff` successfully deleted.</success>',
             '<success>`bootstrap-icons.woff2` successfully deleted.</success>',
@@ -278,14 +266,10 @@ class InstallCommandTest extends TestCase
             '<success>`bootstrap.css.map` successfully copied.</success>',
             '<success>`bootstrap.min.css` successfully copied.</success>',
             '<success>`bootstrap.min.css.map` successfully copied.</success>',
-            '<success>`bootstrap.js` successfully copied.</success>',
-            '<success>`bootstrap.js.map` successfully copied.</success>',
-            '<success>`bootstrap.min.js` successfully copied.</success>',
-            '<success>`bootstrap.min.js.map` successfully copied.</success>',
-            '<success>`popper.js` successfully copied.</success>',
-            '<success>`popper.js.map` successfully copied.</success>',
-            '<success>`popper.min.js` successfully copied.</success>',
-            '<success>`popper.min.js.map` successfully copied.</success>',
+            '<success>`bootstrap.bundle.js` successfully copied.</success>',
+            '<success>`bootstrap.bundle.js.map` successfully copied.</success>',
+            '<success>`bootstrap.bundle.min.js` successfully copied.</success>',
+            '<success>`bootstrap.bundle.min.js.map` successfully copied.</success>',
             '<success>`bootstrap-icons.css` successfully copied.</success>',
             '<success>`bootstrap-icons.woff` successfully copied.</success>',
             '<success>`bootstrap-icons.woff2` successfully copied.</success>',
@@ -310,9 +294,8 @@ class InstallCommandTest extends TestCase
         $testPackageFileContents = <<<EOT
 {
     "dependencies": {
-        "@popperjs/core": "^2.9.2",
-        "bootstrap": "^5.0.1",
-        "bootstrap-icons": "^1.5.0"
+        "bootstrap": "^5.3.3",
+        "bootstrap-icons": "^1.11.3"
     }
 }
 
@@ -326,57 +309,71 @@ EOT;
     "packages": {
         "": {
             "dependencies": {
-                "@popperjs/core": "^2.9.2",
-                "bootstrap": "^5.0.1",
-                "bootstrap-icons": "^1.5.0"
+                "bootstrap": "^5.3.3",
+                "bootstrap-icons": "^1.11.3"
             }
         },
         "node_modules/@popperjs/core": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.2.tgz",
-            "integrity": "sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==",
+            "version": "2.11.8",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
             }
         },
         "node_modules/bootstrap": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.0.1.tgz",
-            "integrity": "sha512-Fl79+wsLOZKoiU345KeEaWD0ik8WKRI5zm0YSPj2oF1Qr+BO7z0fco6GbUtqjoG1h4VI89PeKJnMsMMVQdKKTw==",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/bootstrap"
-            },
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+            "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/twbs"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/bootstrap"
+                }
+            ],
             "peerDependencies": {
-                "@popperjs/core": "^2.9.2"
+                "@popperjs/core": "^2.11.8"
             }
         },
         "node_modules/bootstrap-icons": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.5.0.tgz",
-            "integrity": "sha512-44feMc7DE1Ccpsas/1wioN8ewFJNquvi5FewA06wLnqct7CwMdGDVy41ieHaacogzDqLfG8nADIvMNp9e4bfbA==",
-            "engines": {
-                "node": ">=10"
-            }
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.11.3.tgz",
+            "integrity": "sha512-+3lpHrCw/it2/7lBL15VR0HEumaBss0+f/Lb6ZvHISn1mlK83jjFpooTLsMWbIjJMDjDjOExMsTxnXSIT4k4ww==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/twbs"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/bootstrap"
+                }
+            ]
         }
     },
     "dependencies": {
         "@popperjs/core": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.2.tgz",
-            "integrity": "sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q=="
+            "version": "2.11.8",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+            "peer": true
         },
         "bootstrap": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.0.1.tgz",
-            "integrity": "sha512-Fl79+wsLOZKoiU345KeEaWD0ik8WKRI5zm0YSPj2oF1Qr+BO7z0fco6GbUtqjoG1h4VI89PeKJnMsMMVQdKKTw==",
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+            "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
             "requires": {}
         },
         "bootstrap-icons": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.5.0.tgz",
-            "integrity": "sha512-44feMc7DE1Ccpsas/1wioN8ewFJNquvi5FewA06wLnqct7CwMdGDVy41ieHaacogzDqLfG8nADIvMNp9e4bfbA=="
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.11.3.tgz",
+            "integrity": "sha512-+3lpHrCw/it2/7lBL15VR0HEumaBss0+f/Lb6ZvHISn1mlK83jjFpooTLsMWbIjJMDjDjOExMsTxnXSIT4k4ww=="
         }
     }
 }
@@ -397,22 +394,16 @@ EOT;
         $this->assertStringEqualsFile($pluginPath . 'package-lock.json', $testLockFileContents);
 
         $package = json_decode(
-            file_get_contents($pluginPath . 'node_modules' . DS . '@popperjs' . DS . 'core' . DS . 'package.json'),
-            true
-        );
-        $this->assertSame('2.9.2', $package['version']);
-
-        $package = json_decode(
             file_get_contents($pluginPath . 'node_modules' . DS . 'bootstrap' . DS . 'package.json'),
             true
         );
-        $this->assertSame('5.0.1', $package['version']);
+        $this->assertSame('5.3.3', $package['version']);
 
         $package = json_decode(
             file_get_contents($pluginPath . 'node_modules' . DS . 'bootstrap-icons' . DS . 'package.json'),
             true
         );
-        $this->assertSame('1.5.0', $package['version']);
+        $this->assertSame('1.11.3', $package['version']);
 
         $this->exec('bootstrap install --latest');
 
@@ -420,24 +411,17 @@ EOT;
         $this->assertStringEqualsFile($pluginPath . 'package-lock.json', $testLockFileContents);
 
         $package = json_decode(
-            file_get_contents($pluginPath . 'node_modules' . DS . '@popperjs' . DS . 'core' . DS . 'package.json'),
-            true
-        );
-        $this->assertTrue(version_compare($package['version'], '2.9.2', '>'));
-        $this->assertTrue(version_compare($package['version'], '3.0.0', '<'));
-
-        $package = json_decode(
             file_get_contents($pluginPath . 'node_modules' . DS . 'bootstrap' . DS . 'package.json'),
             true
         );
-        $this->assertTrue(version_compare($package['version'], '5.0.1', '>'));
+        $this->assertTrue(version_compare($package['version'], '5.3.3', '>='));
         $this->assertTrue(version_compare($package['version'], '6.0.0', '<'));
 
         $package = json_decode(
             file_get_contents($pluginPath . 'node_modules' . DS . 'bootstrap-icons' . DS . 'package.json'),
             true
         );
-        $this->assertTrue(version_compare($package['version'], '1.5.0', '>'));
+        $this->assertTrue(version_compare($package['version'], '1.11.3', '>='));
         $this->assertTrue(version_compare($package['version'], '2.0.0', '<'));
 
         $this->assertTrue(rename($pluginPath . 'package.json.bak', $pluginPath . 'package.json'));


### PR DESCRIPTION
Drop popper as a direct dependency as it's now included in bootstrap bundle.
