### PR TITLE
Fix the class attribute when the field has add-ons

### DIFF
--- a/src/View/Widget/InputGroupTrait.php
+++ b/src/View/Widget/InputGroupTrait.php
@@ -73,6 +73,7 @@ trait InputGroupTrait
                 $errorClass &&
                 $context->hasError($data['fieldName'])
             ) {
+                $attrs['class'] = (array)$attrs['class'];
                 $attrs['class'][] = $errorClass;
             }
 


### PR DESCRIPTION
## Description

Fix the class attribute when the field has add-ons (with add-on options) and a validation error occurs.

## Related Issues

#424 