### PR TITLE
Add getDescription() to all commands

### DIFF
--- a/src/Command/BootstrapCommand.php
+++ b/src/Command/BootstrapCommand.php
@@ -17,6 +17,14 @@ use Cake\Utility\Text;
 class BootstrapCommand extends Command implements CommandCollectionAwareInterface
 {
     /**
+     * @return string
+     */
+    public static function getDescription(): string
+    {
+        return 'BootstrapUI commands entry point.';
+    }
+
+    /**
      * The command collection to get help on.
      *
      * @var \Cake\Console\CommandCollection

--- a/src/Command/CopyLayoutsCommand.php
+++ b/src/Command/CopyLayoutsCommand.php
@@ -16,6 +16,14 @@ use Cake\Utility\Filesystem;
 class CopyLayoutsCommand extends Command
 {
     /**
+     * @return string
+     */
+    public static function getDescription(): string
+    {
+        return 'Copy sample layouts to app templates.';
+    }
+
+    /**
      * @inheritDoc
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -18,6 +18,14 @@ use Cake\Utility\Filesystem;
 class InstallCommand extends Command
 {
     /**
+     * @return string
+     */
+    public static function getDescription(): string
+    {
+        return 'Install Bootstrap dependencies and link assets.';
+    }
+
+    /**
      * @inheritDoc
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int

--- a/src/Command/ModifyViewCommand.php
+++ b/src/Command/ModifyViewCommand.php
@@ -14,6 +14,14 @@ use Cake\Console\ConsoleOptionParser;
 class ModifyViewCommand extends Command
 {
     /**
+     * @return string
+     */
+    public static function getDescription(): string
+    {
+        return 'Modify AppView to extend UIView.';
+    }
+
+    /**
      * @inheritDoc
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int


### PR DESCRIPTION
Status quo:
```
bootstrap:
  bootstrap                      
  bootstrap copy_layouts         
  bootstrap install              
  bootstrap modify_view          
```
without descr

## Summary
- Add static `getDescription()` method to BootstrapCommand, InstallCommand, CopyLayoutsCommand, and ModifyViewCommand
- This ensures commands display descriptions in `bin/cake` command listing