### PR TITLE
Replace backticks with shell_exec for a deprecation

### DIFF
--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -145,7 +145,7 @@ class InstallCommand extends Command
             $command = 'which npm';
         }
 
-        return !!`$command`;
+        return !!shell_exec($command);
     }
 
     /**


### PR DESCRIPTION
Fixes:

```
2026-02-09 18:01:55 debug: The backtick (`) operator is deprecated, use shell_exec() instead in /var/www/html/vendor/friendsofcake/bootstrap-ui/src/Command/InstallCommand.php on line 148
Trace:
Cake\Error\ErrorTrap->handleError() /var/www/html/vendor/composer/ClassLoader.php, line 576
/var/www/html/vendor/composer/ClassLoader.php /var/www/html/vendor/composer/ClassLoader.php, line 576
/var/www/html/vendor/composer/ClassLoader.php /var/www/html/vendor/composer/ClassLoader.php, line 427
Composer\Autoload\ClassLoader->loadClass() [internal], line ??
/var/www/html/vendor/cakephp/cakephp/src/Console/CommandCollection.php /var/www/html/vendor/cakephp/cakephp/src/Console/CommandCollection.php, line 68
Cake\Console\CommandCollection->add() /var/www/html/vendor/friendsofcake/bootstrap-ui/src/BootstrapUIPlugin.php, line 64
BootstrapUI\BootstrapUIPlugin->console() /var/www/html/vendor/cakephp/cakephp/src/Http/BaseApplication.php, line 256
Cake\Http\BaseApplication->pluginConsole() /var/www/html/vendor/cakephp/cakephp/src/Console/CommandRunner.php, line 157
Cake\Console\CommandRunner->run() /var/www/html/bin/cake.php, line 10
[main]
```