### PR TITLE
Allow icon() to work with empty namespace and/or prefix

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -91,10 +91,20 @@ class HtmlHelper extends CoreHtmlHelper
             'class' => null,
         ];
 
-        $classes = [$options['namespace'], $options['prefix'] . '-' . $name];
-        if (!empty($options['size'])) {
-            $classes[] = $options['prefix'] . '-' . $options['size'];
+        $classes = [];
+        if ($options['namespace']) {
+            $classes[] = $options['namespace'];
         }
+
+        if ($options['prefix']) {
+            $classes[] = $options['prefix'] . '-' . $name;
+            if (!empty($options['size'])) {
+                $classes[] = $options['prefix'] . '-' . $options['size'];
+            }
+        } else {
+            $classes[] = $name;
+        }
+
         $options = $this->injectClasses($classes, $options);
 
         return $this->formatTemplate('tag', [

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -75,4 +75,66 @@ class HtmlHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
     }
+
+    public function testIconWithoutNamespace(): void
+    {
+        // Remixicon style: ri-home-line (no namespace, just prefix)
+        $result = $this->Html->icon('home-line', ['namespace' => null, 'prefix' => 'ri']);
+        $expected = [
+            'i' => ['class' => 'ri-home-line'],
+            '/i',
+        ];
+        $this->assertHtml($expected, $result);
+
+        // With empty string namespace
+        $result = $this->Html->icon('home-line', ['namespace' => '', 'prefix' => 'ri']);
+        $expected = [
+            'i' => ['class' => 'ri-home-line'],
+            '/i',
+        ];
+        $this->assertHtml($expected, $result);
+
+        // With size
+        $result = $this->Html->icon('home-line', ['namespace' => null, 'prefix' => 'ri', 'size' => 'lg']);
+        $expected = [
+            'i' => ['class' => 'ri-home-line ri-lg'],
+            '/i',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testIconWithoutPrefix(): void
+    {
+        // Icon set with namespace but no prefix
+        $result = $this->Html->icon('home', ['namespace' => 'icons', 'prefix' => null]);
+        $expected = [
+            'i' => ['class' => 'icons home'],
+            '/i',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testIconWithoutNamespaceAndPrefix(): void
+    {
+        // Hypothetical icon set using custom tag and just the icon name
+        $result = $this->Html->icon('home', ['tag' => 'icon', 'namespace' => null, 'prefix' => null]);
+        $expected = [
+            'icon' => ['class' => 'home'],
+            '/icon',
+        ];
+        $this->assertHtml($expected, $result);
+
+        // With additional class
+        $result = $this->Html->icon('home', [
+            'tag' => 'icon',
+            'namespace' => null,
+            'prefix' => null,
+            'class' => 'fs-5',
+        ]);
+        $expected = [
+            'icon' => ['class' => 'fs-5 home'],
+            '/icon',
+        ];
+        $this->assertHtml($expected, $result);
+    }
 }


### PR DESCRIPTION
## Summary

- Makes `namespace` optional - null/empty values are now properly omitted instead of adding extra spaces
- Makes `prefix` optional - when null/empty, uses just the icon name without a prefix-dash

This allows using icon sets like [Remixicon](https://remixicon.com/) that don't use a namespace:

```php
// Before: produced <i class="  ri-home-line"></i> (extra spaces)
// After: produces <i class="ri-home-line"></i>
$this->Html->icon('home-line', ['prefix' => 'ri', 'namespace' => null]);
```

Also supports hypothetical icon sets using just the icon name:

```php
// Produces <icon class="home"></icon>
$this->Html->icon('home', ['tag' => 'icon', 'namespace' => null, 'prefix' => null]);
```

Fixes #429