### PR TITLE
Update badge docs: fix class prefixes and document skip option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1005,7 +1005,7 @@ echo $this->Html->badge('Text');
 ```
 
 ```html
-<span class="badge bg-secondary">Text</span>
+<span class="badge text-bg-secondary">Text</span>
 ```
 
 #### Background colors
@@ -1021,7 +1021,24 @@ echo $this->Html->badge('Text', [
 ```
 
 ```html
-<span class="badge bg-danger">Text</span>
+<span class="badge text-bg-danger">Text</span>
+```
+
+#### Using non-theme background colors
+
+The helper only recognizes Bootstrap's semantic theme color names (`primary`, `secondary`, `success`, etc.).
+If you need to use a non-theme utility class like `bg-white`, use the `skip` option to prevent the default
+`secondary` color from being injected:
+
+```php
+echo $this->Html->badge('Text', [
+    'class' => 'bg-white text-dark',
+    'skip' => 'secondary',
+]);
+```
+
+```html
+<span class="bg-white text-dark badge">Text</span>
 ```
 
 #### Using a different HTML tag
@@ -1035,7 +1052,7 @@ echo $this->Html->badge('Text', [
 ```
 
 ```html
-<div class="badge bg-secondary">Text</div>
+<div class="badge text-bg-secondary">Text</div>
 ```
 
 ### Icons

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,5 +7,3 @@ parameters:
 	ignoreErrors:
 		-
 			identifier: missingType.iterableValue
-		-
-			identifier: missingType.generics

--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -8,6 +8,8 @@ use UnexpectedValueException;
 
 /**
  * FlashHelper class to render flash messages.
+ *
+ * @extends \Cake\View\Helper<\Cake\View\View>
  */
 class FlashHelper extends Helper
 {


### PR DESCRIPTION
## Summary

- Fix badge HTML output examples to use `text-bg-` prefix instead of `bg-` (matching actual output since Bootstrap 5.3 support)
- Document the `skip` option for using non-theme background colors on badges (refs #368)
- Fix psalm `MissingTemplateParam` error in FlashHelper by adding `@extends` annotation