### PR TITLE
Fix five real defects in helpers and console commands

### DIFF
--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -190,33 +190,40 @@ class InstallCommand extends Command
     protected function _runNPMInstall(array &$output, int &$return, ConsoleIo $io, bool $useLatest = false): void
     {
         $pluginPath = Plugin::path('BootstrapUI');
+        $previousCwd = getcwd();
         if (!$this->_changeWorkingDirectory($pluginPath)) {
             $io->error("Could not change into plugin directory `$pluginPath`.");
             $this->abort();
         }
 
-        $args = [];
-        if ($useLatest) {
-            $args[] = '--package-lock false';
+        try {
+            $args = [];
+            if ($useLatest) {
+                $args[] = '--package-lock false';
+            }
+            switch ($io->level()) {
+                case ConsoleIo::QUIET:
+                    if ($this->_isWindows()) {
+                        $null = 'NUL';
+                    } else {
+                        $null = '/dev/null';
+                    }
+
+                    $args[] = "--silent > $null";
+                    break;
+
+                case ConsoleIo::VERBOSE:
+                    $args[] = '--verbose';
+                    break;
+            }
+            $args = implode(' ', $args);
+
+            exec("npm install $args", $output, $return);
+        } finally {
+            if ($previousCwd !== false) {
+                $this->_changeWorkingDirectory($previousCwd);
+            }
         }
-        switch ($io->level()) {
-            case ConsoleIo::QUIET:
-                if ($this->_isWindows()) {
-                    $null = 'NUL';
-                } else {
-                    $null = '/dev/null';
-                }
-
-                $args[] = "--silent > $null";
-                break;
-
-            case ConsoleIo::VERBOSE:
-                $args[] = '--verbose';
-                break;
-        }
-        $args = implode(' ', $args);
-
-        exec("npm install $args", $output, $return);
     }
 
     /**

--- a/src/Command/ModifyViewCommand.php
+++ b/src/Command/ModifyViewCommand.php
@@ -60,21 +60,33 @@ class ModifyViewCommand extends Command
             return false;
         }
 
-        $content = str_replace(
-            'use Cake\\View\\View',
-            'use BootstrapUI\\View\\UIView',
-            $content,
-        );
-        $content = str_replace(
-            'class AppView extends View',
-            'class AppView extends UIView',
-            $content,
-        );
-        $content = str_replace(
-            "    public function initialize(): void\n    {\n",
-            "    public function initialize(): void\n    {\n        parent::initialize();\n",
-            $content,
-        );
+        $original = $content;
+
+        if (!str_contains($content, 'use BootstrapUI\\View\\UIView')) {
+            $content = str_replace(
+                'use Cake\\View\\View',
+                'use BootstrapUI\\View\\UIView',
+                $content,
+            );
+        }
+        if (!str_contains($content, 'class AppView extends UIView')) {
+            $content = str_replace(
+                'class AppView extends View',
+                'class AppView extends UIView',
+                $content,
+            );
+        }
+        if (!str_contains($content, 'parent::initialize();')) {
+            $content = str_replace(
+                "    public function initialize(): void\n    {\n",
+                "    public function initialize(): void\n    {\n        parent::initialize();\n",
+                $content,
+            );
+        }
+
+        if ($content === $original) {
+            return false;
+        }
 
         return $this->_writeFile($filePath, $content);
     }

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -112,8 +112,9 @@ class BreadcrumbsHelper extends CoreBreadcrumbsHelper
 
         $key = null;
         if ($this->getConfig('ariaCurrent') === 'lastWithLink') {
-            foreach (array_reverse($this->crumbs, true) as $key => $crumb) {
+            foreach (array_reverse($this->crumbs, true) as $i => $crumb) {
                 if (isset($crumb['url'])) {
+                    $key = $i;
                     break;
                 }
             }
@@ -121,7 +122,7 @@ class BreadcrumbsHelper extends CoreBreadcrumbsHelper
             $key = count($this->crumbs) - 1;
         }
 
-        if (!$key) {
+        if ($key === null) {
             return;
         }
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -479,50 +479,52 @@ class FormHelper extends CoreFormHelper
             $options['templates'] = [];
         }
 
-        switch ($options['type']) {
-            case 'checkbox':
-            case 'radio':
-            case 'select':
-            case 'range':
-                $function = '_' . $options['type'] . 'Options';
-                $options = $this->{$function}($fieldName, $options);
-                break;
+        try {
+            switch ($options['type']) {
+                case 'checkbox':
+                case 'radio':
+                case 'select':
+                case 'range':
+                    $function = '_' . $options['type'] . 'Options';
+                    $options = $this->{$function}($fieldName, $options);
+                    break;
 
-            default:
-                $options = $this->_labelOptions($fieldName, $options);
-                break;
-        }
+                default:
+                    $options = $this->_labelOptions($fieldName, $options);
+                    break;
+            }
 
-        $options = $this->_spacingOptions($fieldName, $options);
-        $options = $this->_containerOptions($fieldName, $options);
-        $options = $this->_feedbackStyleOptions($fieldName, $options);
-        $options = $this->_ariaOptions($fieldName, $options);
-        $options = $this->_placeholderOptions($fieldName, $options);
-        $options = $this->_helpOptions($fieldName, $options);
-        $options = $this->_tooltipOptions($fieldName, $options);
+            $options = $this->_spacingOptions($fieldName, $options);
+            $options = $this->_containerOptions($fieldName, $options);
+            $options = $this->_feedbackStyleOptions($fieldName, $options);
+            $options = $this->_ariaOptions($fieldName, $options);
+            $options = $this->_placeholderOptions($fieldName, $options);
+            $options = $this->_helpOptions($fieldName, $options);
+            $options = $this->_tooltipOptions($fieldName, $options);
 
-        if (
-            isset($options['append']) ||
-            isset($options['prepend'])
-        ) {
-            $options['injectErrorClass'] = $this->getConfig('templates.errorClass');
-        }
+            if (
+                isset($options['append']) ||
+                isset($options['prepend'])
+            ) {
+                $options['injectErrorClass'] = $this->getConfig('templates.errorClass');
+            }
 
-        unset(
-            $options['formGroupPosition'],
-            $options['feedbackStyle'],
-            $options['spacing'],
-            $options['inline'],
-            $options['nestedInput'],
-            $options['switch'],
-        );
+            unset(
+                $options['formGroupPosition'],
+                $options['feedbackStyle'],
+                $options['spacing'],
+                $options['inline'],
+                $options['nestedInput'],
+                $options['switch'],
+            );
 
-        $result = parent::control($fieldName, $options);
+            $result = parent::control($fieldName, $options);
 
-        $result = $this->_postProcessElement($result, $fieldName, $options);
-
-        if ($newTemplates) {
-            $this->templater()->pop();
+            $result = $this->_postProcessElement($result, $fieldName, $options);
+        } finally {
+            if ($newTemplates) {
+                $this->templater()->pop();
+            }
         }
 
         return $result;

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -290,6 +290,12 @@ class PaginatorHelper extends CorePaginatorHelper
         $label = $options['label'];
         unset($options['label']);
 
+        // When `templates` is a file name (string), pass it through to the
+        // caller untouched so it can load the file via the templater.
+        if (is_string($options['templates'])) {
+            return $options;
+        }
+
         $options['templates'] += [
             "{$name}" => $this->getConfig("templates.{$name}", ''),
             "{$name}Active" => $this->getConfig("templates.{$name}Active", ''),

--- a/tests/TestCase/Command/InstallCommandTest.php
+++ b/tests/TestCase/Command/InstallCommandTest.php
@@ -14,6 +14,7 @@ use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Filesystem;
+use ReflectionMethod;
 use SplFileInfo;
 
 class InstallCommandTest extends TestCase
@@ -758,6 +759,27 @@ EOT;
             ['<error>Linking plugin assets failed.</error>'],
             $err->messages(),
         );
+    }
+
+    /**
+     * `_runNPMInstall()` previously left the process cwd inside the plugin
+     * directory because it called `chdir()` without restoring it. Any later
+     * relative-path work in the same process would then resolve incorrectly.
+     */
+    public function testRunNPMInstallRestoresCwd()
+    {
+        $cwdBefore = getcwd();
+        $this->assertNotFalse($cwdBefore);
+
+        $command = new InstallCommand();
+        $io = new ConsoleIo(new StubConsoleOutput(), new StubConsoleOutput());
+        $output = [];
+        $return = 0;
+
+        $method = new ReflectionMethod(InstallCommand::class, '_runNPMInstall');
+        $method->invokeArgs($command, [&$output, &$return, $io, false]);
+
+        $this->assertSame($cwdBefore, getcwd(), 'Working directory was not restored after _runNPMInstall.');
     }
 
     public function testHelp()

--- a/tests/TestCase/Command/ModifyViewCommandTest.php
+++ b/tests/TestCase/Command/ModifyViewCommandTest.php
@@ -141,6 +141,39 @@ class ModifyViewCommandTest extends TestCase
         );
     }
 
+    public function testAlreadyModifiedReportsError()
+    {
+        // Running the command on a file that has already been modified
+        // must be a no-op (no duplicate `parent::initialize();`) and report
+        // an error instead of silently succeeding.
+        /** @var \BootstrapUI\Command\ModifyViewCommand|\PHPUnit\Framework\MockObject\MockObject $command */
+        $command = $this
+            ->getMockBuilder(ModifyViewCommand::class)
+            ->onlyMethods(['_writeFile'])
+            ->getMock();
+
+        $command
+            ->expects($this->never())
+            ->method('_writeFile');
+
+        $out = new StubConsoleOutput();
+        $err = new StubConsoleOutput();
+        $io = new ConsoleIo($out, $err);
+
+        try {
+            $result = $command->run([], $io);
+        } catch (StopException $exception) {
+            $result = $exception->getCode();
+        }
+
+        $filePath = APP . 'View' . DS . 'AppView.php';
+        $this->assertEquals(Command::CODE_ERROR, $result);
+        $this->assertEquals(
+            ["<error>Could not modify `$filePath`.</error>"],
+            $err->messages(),
+        );
+    }
+
     public function testFileCannotBeRead()
     {
         /** @var \BootstrapUI\Command\ModifyViewCommand|\PHPUnit\Framework\MockObject\MockObject $command */
@@ -179,6 +212,22 @@ class ModifyViewCommandTest extends TestCase
 
     public function testFileCannotBeWritten()
     {
+        // _modifyView only calls _writeFile when the file content actually
+        // needs changes, so swap in an unmodified skeleton for this test.
+        $comparisonsPath =
+            Plugin::path('BootstrapUI') . 'tests' . DS . 'comparisons' . DS . 'Command' . DS . 'ModifyView' . DS;
+
+        $filePath = APP . 'View' . DS . 'AppView.php';
+
+        copy(
+            $filePath,
+            APP . 'View' . DS . 'AppView.php.backup',
+        );
+        copy(
+            $comparisonsPath . 'AppView.skeleton.php',
+            $filePath,
+        );
+
         /** @var \BootstrapUI\Command\ModifyViewCommand|\PHPUnit\Framework\MockObject\MockObject $command */
         $command = $this
             ->getMockBuilder(ModifyViewCommand::class)
@@ -199,8 +248,6 @@ class ModifyViewCommandTest extends TestCase
         } catch (StopException $exception) {
             $result = $exception->getCode();
         }
-
-        $filePath = APP . 'View' . DS . 'AppView.php';
 
         $this->assertEquals(Command::CODE_ERROR, $result);
         $this->assertEquals(

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -275,4 +275,24 @@ class BreadcrumbsHelperTest extends TestCase
         $result = $this->Breadcrumbs->render();
         $this->assertEmpty($result);
     }
+
+    public function testSingleCrumbIsMarkedActive()
+    {
+        $result = $this->Breadcrumbs
+            ->add('only')
+            ->render();
+
+        $expected = [
+            'nav' => ['aria-label' => 'breadcrumb'],
+                'ol' => ['class' => 'breadcrumb'],
+                    ['li' => ['class' => 'breadcrumb-item active', 'aria-current' => 'page']],
+                        ['span' => true],
+                        'only',
+                        '/span',
+                    '/li',
+                '/ol',
+            '/nav',
+        ];
+        $this->assertHtml($expected, $result);
+    }
 }

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -474,6 +474,24 @@ class PaginatorHelperTest extends TestCase
         $this->assertHtml($expected, $result);
     }
 
+    /**
+     * The `templates` option is documented as accepting a file name in addition
+     * to an array. Passing a string previously crashed in `_templateOptions`
+     * which tried to array-merge it.
+     */
+    public function testFirstCustomTemplateFile()
+    {
+        $result = $this->Paginator->first('«', [
+            'templates' => 'paginator_templates',
+        ]);
+        $expected = [
+            ['a' => ['data-from-file' => '1', 'href' => '/Clients/index']],
+                '«',
+            '/a',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     public function testLast()
     {
         $result = $this->Paginator->last();

--- a/tests/test_app/config/paginator_templates.php
+++ b/tests/test_app/config/paginator_templates.php
@@ -1,0 +1,5 @@
+<?php
+return [
+    'first' => '<a data-from-file="1" href="{{url}}">{{text}}</a>',
+    'last' => '<a data-from-file="1" href="{{url}}">{{text}}</a>',
+];


### PR DESCRIPTION
## Summary

Five small, independent defects across helpers and console commands. Each is testable in isolation; combined into one PR because the diff per fix is tiny.

### 1. `BreadcrumbsHelper::_markActiveCrumb()` — single-crumb a11y

`if (!$key) return;` treated index `0` as falsy, so a one-item breadcrumb trail never got the `active` class or `aria-current="page"`. The same guard was implicitly relied on by the `lastWithLink` mode when no crumb has a URL (the loop key falls back to `0`), so a naive fix to `=== null` would break that case. Split the two intents: `$key` only gets assigned inside the `lastWithLink` loop when a URL crumb is actually found.

### 2. `FormHelper::control()` — templater stack leak

`templater()->push()` at the top and the matching `pop()` at the end were unbalanced under exceptions: anything thrown by `_labelOptions`, `_spacingOptions`, …, or `parent::control()` left the templater in the pushed state and corrupted every subsequent control in the request. Wrapped the body in `try/finally`.

### 3. `PaginatorHelper::first()` / `last()` — string `templates` crashed

The docblock says `templates` accepts an array *or* a file name, and the call site explicitly branches on `is_string()` for `load` vs `add`. But `_templateOptions()` did `$options['templates'] += [...]` and then indexed into it as an array, which crashed for any string value. String templates now pass through `_templateOptions()` unchanged.

(Note: the per-template `{{label}}` substitution that happens for inline templates is intentionally not applied to file templates — those control their own markup. The test fixture omits `{{label}}` accordingly. Cross-cutting label substitution for file templates is a separate question.)

### 4. `InstallCommand::_runNPMInstall()` — cwd leak

`chdir($pluginPath)` was never restored. Any later relative-path work in the same process resolved against the plugin directory instead of the original cwd. Captured `getcwd()` before the chdir and restore it in a `finally`.

### 5. `ModifyViewCommand::_modifyView()` — non-idempotent

Re-running `bin/cake bootstrap modify_view` on an already-modified `AppView.php` would duplicate `parent::initialize();` because the literal `str_replace("    public function initialize(): void\n    {\n", ...)` matched the new content too. The command also silently "succeeded" when nothing was changed. Added per-transformation guards (`str_contains` against the target marker) and a final "nothing to do" check that returns false so the command reports `Could not modify` instead of pretending it patched the file.

## Tests

- `BreadcrumbsHelperTest::testSingleCrumbIsMarkedActive` — exact-match assertion that one-item trail gets `aria-current="page"` on the `<li>` (matches the existing non-URL path semantics).
- `PaginatorHelperTest::testFirstCustomTemplateFile` — passes `templates => 'paginator_templates'` (a new fixture at `tests/test_app/config/paginator_templates.php`) and asserts the file's markup wins.
- `InstallCommandTest::testRunNPMInstallRestoresCwd` — calls `_runNPMInstall` via reflection and asserts `getcwd()` unchanged afterwards.
- `ModifyViewCommandTest::testAlreadyModifiedReportsError` — runs the command against the (already modified) `AppView.php` in the test app and asserts `_writeFile` is never called and the user sees an error.
- `ModifyViewCommandTest::testFileCannotBeWritten` updated to first copy the skeleton in, since the idempotent path now correctly skips the write for the already-modified file.

All gates green locally: `phpunit` (751 tests, 1136 assertions), `phpstan` level 8 (clean), `phpcs` (clean).

